### PR TITLE
Add @locomotivemtl/postcss-remove-double-parentheses plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,7 @@ import tailwind from '@astrojs/tailwind';
 import svgSprite from 'astro-svg-sprite';
 import tailwindConfig from './tailwind.config';
 import postcssTailwindShortcuts from '@locomotivemtl/postcss-tailwind-shortcuts';
+import removeDoubleParentheses from '@locomotivemtl/postcss-remove-double-parentheses';
 
 const isProd = import.meta.env.PROD;
 
@@ -23,7 +24,10 @@ export default defineConfig({
                 }
             },
             postcss: {
-                plugins: [postcssTailwindShortcuts(tailwindConfig.theme, { prefix: 'theme' })]
+                plugins: [
+                    postcssTailwindShortcuts(tailwindConfig.theme, { prefix: 'theme' }),
+                    removeDoubleParentheses(),
+                ]
             }
         },
         esbuild: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
             postcss: {
                 plugins: [
                     postcssTailwindShortcuts(tailwindConfig.theme, { prefix: 'theme' }),
-                    removeDoubleParentheses(),
+                    removeDoubleParentheses()
                 ]
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "typescript": "^5.4.5"
             },
             "devDependencies": {
+                "@locomotivemtl/postcss-remove-double-parentheses": "^1.0.0",
                 "@locomotivemtl/postcss-tailwind-shortcuts": "^1.0.5",
                 "prettier": "^3.3.1",
                 "prettier-plugin-astro": "^0.14.0",
@@ -1457,6 +1458,16 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@locomotivemtl/grid-helper/-/grid-helper-1.0.0.tgz",
             "integrity": "sha512-/HkUBf2qR2cfZ9vzyYvLWO532tPy29qoBXbwbJ8dxkI+FucZMu8yjiYWnjy+fRqYpu1PJ18ojLiIyLOhtfdRFw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@locomotivemtl/postcss-remove-double-parentheses": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@locomotivemtl/postcss-remove-double-parentheses/-/postcss-remove-double-parentheses-1.0.0.tgz",
+            "integrity": "sha512-neTQC9xMoiJFPhOt/w3T+ElyXNRQz9UF7c/76lzRDYUWc2eMXl5LV0SRilx20OaLsON6gBf+ssyJ9tYZJFpVDA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "typescript": "^5.4.5"
     },
     "devDependencies": {
+        "@locomotivemtl/postcss-remove-double-parentheses": "^1.0.0",
         "@locomotivemtl/postcss-tailwind-shortcuts": "^1.0.5",
         "prettier": "^3.3.1",
         "prettier-plugin-astro": "^0.14.0",


### PR DESCRIPTION
This PR introduces a new [PostCSS plugin](https://www.npmjs.com/package/@locomotivemtl/postcss-remove-double-parentheses) that removes double parentheses around media queries. We encountered an issue when using the Tailwind `(screen())` function, which was outputting media queries with extra parentheses, such as `@media ((min-width: 700px))`.

While Tailwind [states that](https://tailwindcss.com/docs/using-with-preprocessors#sass) this syntax is still valid, we discovered that it does not work in older versions of Safari (prior to 16.5). In those cases, media queries with double parentheses were not interpreted correctly, leading to styling issues.

<img width="790" alt="image" src="https://github.com/user-attachments/assets/fdbd0fdc-852d-447d-8371-2ddb43e4fbe8">