### PR TITLE
Refactor component manager to use string-based prototype comparison

### DIFF
--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -255,7 +255,7 @@ You can use `$componentsManager.get()` or one of the following helpers `getCompo
 ```ts
 import { getComponentsByPrototype } from '@root/src/scripts/stores/componentManager';
 
-const $allFoo = getComponentsByPrototype(Foo);
+const $allFoo = getComponentsByPrototype('Foo'); // Use the class name as a string
 $allFoo.forEach(($foo) => {
     $foo.doSomething(); // Call method on each Foo instance
 });
@@ -277,10 +277,15 @@ if ($foo) {
 ```ts
 import { getComponentsByPrototype } from '@root/src/scripts/stores/componentManager';
 
-const $allFoo = getComponentsByPrototype(Foo, this);
+// Exclude the current instance by passing it as the second argument
+const $allFoo = getComponentsByPrototype('Foo', this);
+
 $allFoo.forEach(($foo) => {
-    $foo.doSomething(); // Call method on each Foo instance
+    $foo.doSomething(); // Call method on each Foo instance except the current one
 });
+
+// You can also exclude components by passing a selector string or an array of selectors
+const $filteredComponents = getComponentsByPrototype('Bar', ['#exclude-me', '.ignore-this']);
 ```
 
 ### Best Practices

--- a/src/scripts/stores/componentManager.ts
+++ b/src/scripts/stores/componentManager.ts
@@ -1,8 +1,12 @@
 import { atom } from 'nanostores';
 
 export class ComponentElement extends HTMLElement {
+    prototypeType: string;
+
     constructor() {
         super();
+
+        this.prototypeType = this.constructor.name;
 
         if (this.id === '') {
             const index = $componentsManagerIncrement.get() + 1;
@@ -36,15 +40,15 @@ export class ComponentElement extends HTMLElement {
 }
 
 export const $componentsManagerIncrement = atom<number>(0);
-export const $componentsManager = atom<HTMLElement[]>([]);
+export const $componentsManager = atom<ComponentElement[]>([]);
 
 export const getComponentById = (id: string) => {
     return $componentsManager.get().find(($component) => $component.id === id);
 };
 
 export const getComponentsByPrototype = (
-    prototype: any,
-    selectorsToExclude: string[] | string | HTMLElement = []
+    prototype: string,
+    selectorsToExclude: string[] | string | HTMLElement | ComponentElement = []
 ) => {
     let excludedSelectors: string[] = [];
 
@@ -56,10 +60,12 @@ export const getComponentsByPrototype = (
         excludedSelectors = [`#${selectorsToExclude.id}`];
     }
 
-    return $componentsManager.get().filter(($component) => {
-        return (
-            $component instanceof prototype &&
-            !excludedSelectors.some((selector: string) => $component.matches(selector))
-        );
-    });
+    return ($componentsManager.get() as ComponentElement[]).filter(
+        ($component: ComponentElement) => {
+            return (
+                prototype === $component.prototypeType &&
+                !excludedSelectors.some((selector: string) => $component.matches(selector))
+            );
+        }
+    );
 };


### PR DESCRIPTION
### Summary:
This PR refactors how components are retrieved and filtered by their prototype type. Instead of using the `instanceof` check, the method `getComponentsByPrototype()` now accepts a string representing the component's class name. This change removes the need to import the class definition in the files that use this utility.

### Changes Made:

- Modified the `ComponentElement` class to include a `prototypeType` property that stores the class name.
- Updated the `getComponentsByPrototype()` method to compare the `prototypeType` string instead of using `instanceof`.
- Updated `$componentsManager` to store `ComponentElement[]` rather than `HTMLElement[]` for stronger typing.
- Updated the README to reflect these changes, including usage examples with string-based prototype access.