### PR TITLE
Prevent $screen and $screenDebounce from updating twice on resize

### DIFF
--- a/src/scripts/stores/screen.ts
+++ b/src/scripts/stores/screen.ts
@@ -22,12 +22,16 @@ export const $screenDebounce = map<ScreenDebounceValues>({
 });
 
 window.addEventListener('resize', () => {
-    $screen.setKey('width', window.innerWidth);
-    $screen.setKey('height', window.innerHeight);
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    $screen.set({ width, height });
 });
 
 const debouncedFunction: any = () => {
-    $screenDebounce.setKey('width', window.innerWidth);
-    $screenDebounce.setKey('height', window.innerHeight);
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    $screenDebounce.set({ width, height });
 };
 window.addEventListener('resize', debounce(debouncedFunction, 200));


### PR DESCRIPTION
This fix ensures that `$screen` and `$screenDebounce` update only once per resize event instead of firing twice. The issue was caused by separate updates for width and height, triggering multiple reactivity cycles. Now, both values are updated together in a single call