### PR TITLE
Enhancing Component Management & Built-in Element Extension Support

### DIFF
--- a/src/components/Accordion/Accordion.astro
+++ b/src/components/Accordion/Accordion.astro
@@ -10,17 +10,15 @@ const { label, name, class: propsClass, ...rest } = Astro.props;
 const classes = ['c-accordion', propsClass];
 ---
 
-<c-accordion class:list={classes} {...rest}>
-    <details class="c-accordion_details" name={name}>
-        <summary class="c-accordion_summary">
-            <span>{label}</span>
-            <span class="c-accordion_icon" aria-hidden="true">&darr;</span>
-        </summary>
-        <div class="c-accordion_content">
-            <slot />
-        </div>
-    </details>
-</c-accordion>
+<details class:list={classes} name={name} {...rest} is="c-accordion">
+    <summary class="c-accordion_summary">
+        <span>{label}</span>
+        <span class="c-accordion_icon" aria-hidden="true">&darr;</span>
+    </summary>
+    <div class="c-accordion_content">
+        <slot />
+    </div>
+</details>
 
 <style>
     @import 'Accordion.css';

--- a/src/components/Accordion/Accordion.css
+++ b/src/components/Accordion/Accordion.css
@@ -29,7 +29,7 @@
     transform: rotateX(0);
     transition: transform theme-speed() theme-ease();
 
-    .c-accordion_details[open] & {
+    .c-accordion[open] & {
         transform: rotateX(180deg);
     }
 }

--- a/src/components/Accordion/Accordion.ts
+++ b/src/components/Accordion/Accordion.ts
@@ -150,4 +150,6 @@ export default class Accordion extends HTMLDetailsElement {
     }
 }
 
-customElements.define('c-accordion', ComponentElement(Accordion), { extends: 'details' });
+customElements.define('c-accordion', ComponentElement(Accordion, 'Accordion'), {
+    extends: 'details'
+});

--- a/src/components/Accordion/Accordion.ts
+++ b/src/components/Accordion/Accordion.ts
@@ -1,10 +1,9 @@
 import { ComponentElement } from '@scripts/stores/componentManager';
 
-export default class Accordion extends ComponentElement {
+export default class Accordion extends HTMLDetailsElement {
     static readonly DURATION = 300;
     static readonly CLASS_OPEN = 'is-open';
     private onClickBind: any;
-    private $root: HTMLDetailsElement;
     private $summary: HTMLElement;
     private $content: HTMLElement;
     private $parent: HTMLElement | null;
@@ -19,9 +18,8 @@ export default class Accordion extends ComponentElement {
         this.onClickBind = this.onClick.bind(this);
 
         // UI
-        this.$root = this.querySelector('details.c-accordion_details')!;
-        this.$summary = this.$root.querySelector('summary.c-accordion_summary')!;
-        this.$content = this.$root.querySelector('.c-accordion_content')!;
+        this.$summary = this.querySelector('summary.c-accordion_summary')!;
+        this.$content = this.querySelector('.c-accordion_content')!;
         this.$parent = this.closest('[data-accordion-parent]') || null;
 
         // Data
@@ -34,14 +32,10 @@ export default class Accordion extends ComponentElement {
     // Lifecycle
     // =============================================================================
     connectedCallback() {
-        super.connectedCallback();
-
         this.bindEvents();
     }
 
     disconnectedCallback() {
-        super.disconnectedCallback();
-
         this.unbindEvents();
     }
 
@@ -61,11 +55,11 @@ export default class Accordion extends ComponentElement {
     onClick(e: Event) {
         e.preventDefault();
 
-        this.$root.style.overflow = 'hidden';
+        this.style.overflow = 'hidden';
 
-        if (this.isClosing || !this.$root.open) {
+        if (this.isClosing || !this.open) {
             this.start();
-        } else if (this.isExpanding || this.$root.open) {
+        } else if (this.isExpanding || this.open) {
             this.shrink();
         }
     }
@@ -75,18 +69,18 @@ export default class Accordion extends ComponentElement {
     // =============================================================================
     shrink() {
         this.isClosing = true;
-        this.$root.classList.remove(Accordion.CLASS_OPEN);
+        this.classList.remove(Accordion.CLASS_OPEN);
 
         if (this.$parent) this.$parent.classList.remove(Accordion.CLASS_OPEN);
 
-        const startHeight = `${this.$root.offsetHeight}px`;
+        const startHeight = `${this.offsetHeight}px`;
         const endHeight = `${this.$summary.offsetHeight}px`;
 
         if (this.animation) {
             this.animation.cancel();
         }
 
-        this.animation = this.$root.animate(
+        this.animation = this.animate(
             {
                 height: [startHeight, endHeight]
             },
@@ -101,31 +95,31 @@ export default class Accordion extends ComponentElement {
             this.animation.onfinish = () => this.onAnimationFinish(false);
             this.animation.oncancel = () => {
                 this.isClosing = false;
-                this.$root.classList.add(Accordion.CLASS_OPEN);
+                this.classList.add(Accordion.CLASS_OPEN);
             };
         }
     }
 
     start() {
-        this.$root.style.height = `${this.$root.offsetHeight}px`;
+        this.style.height = `${this.offsetHeight}px`;
 
         window.requestAnimationFrame(() => this.expand());
     }
 
     expand() {
         this.isExpanding = true;
-        this.$root.classList.add(Accordion.CLASS_OPEN);
+        this.classList.add(Accordion.CLASS_OPEN);
 
         if (this.$parent) this.$parent.classList.add(Accordion.CLASS_OPEN);
 
-        const startHeight = `${this.$root.offsetHeight}px`;
+        const startHeight = `${this.offsetHeight}px`;
         const endHeight = `${this.$summary.offsetHeight + this.$content.offsetHeight}px`;
 
         if (this.animation) {
             this.animation?.cancel();
         }
 
-        this.animation = this.$root.animate(
+        this.animation = this.animate(
             {
                 height: [startHeight, endHeight]
             },
@@ -139,21 +133,21 @@ export default class Accordion extends ComponentElement {
             this.animation.onfinish = () => this.onAnimationFinish(true);
             this.animation.oncancel = () => {
                 this.isExpanding = false;
-                this.$root.classList.remove(Accordion.CLASS_OPEN);
+                this.classList.remove(Accordion.CLASS_OPEN);
             };
         }
     }
 
     onAnimationFinish(open: boolean) {
-        this.$root.open = open;
+        this.open = open;
 
         this.animation = null;
 
         this.isClosing = false;
         this.isExpanding = false;
 
-        this.$root.style.height = this.$root.style.overflow = '';
+        this.style.height = this.style.overflow = '';
     }
 }
 
-customElements.define('c-accordion', Accordion);
+customElements.define('c-accordion', ComponentElement(Accordion), { extends: 'details' });

--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -3,14 +3,14 @@
 A tiny state manager.
 It uses **many atomic stores** and direct manipulation.
 
--   **Small.** Between 286 and 818 bytes (minified and brotlied).
-    Zero dependencies. It uses [Size Limit] to control size.
--   **Fast.** With small atomic and derived stores, you do not need to call
-    the selector function for all components on every store change.
--   **Tree Shakable.** A chunk contains only stores used by components
-    in the chunk.
--   Designed to move logic from components to stores.
--   Good **TypeScript** support.
+- **Small.** Between 286 and 818 bytes (minified and brotlied).
+  Zero dependencies. It uses [Size Limit] to control size.
+- **Fast.** With small atomic and derived stores, you do not need to call
+  the selector function for all components on every store change.
+- **Tree Shakable.** A chunk contains only stores used by components
+  in the chunk.
+- Designed to move logic from components to stores.
+- Good **TypeScript** support.
 
 ## Screen
 
@@ -207,50 +207,71 @@ export default class Example {
 
 > ⚠️ **Warning**: When working with the store, it's important to understand the distinction between `Store#subscribe()` and `Store#listen(cb)` methods.
 
--   `Store#subscribe()` immediately calls the callback function and subscribes to store changes. It passes the store's current value to the callback upon subscription.
--   `Store#listen(cb)`, on the other hand, only triggers the callback function on the next store change.
+- `Store#subscribe()` immediately calls the callback function and subscribes to store changes. It passes the store's current value to the callback upon subscription.
+- `Store#listen(cb)`, on the other hand, only triggers the callback function on the next store change.
 
 Be mindful of this difference and choose the appropriate method based on your requirements to ensure the expected behavior in your application.
 
 ## Components Manager
 
-The `$componentsManager` is a global store for managing custom Web Component instances. It allows developers to register, track, and interact with all Web Components that extend the `ComponentElement` class. This store provides a centralized way to access component instances by their `id`, `prototype`, or other criteria, enabling cross-component communication.
+The `$componentsManager` is a global store that **tracks and manages** custom Web Component instances. It provides a structured way to register, access, and interact with Web Components dynamically.
 
-### How It Works
+With the updated architecture, **any custom component that extends a native HTML element** can now integrate seamlessly into the component manager.
 
-When a Web Component extends the `ComponentElement` class, it is automatically registered in the `$componentsManager` store when connected to the DOM. Similarly, the component is unregistered when disconnected.
+---
 
-#### Example
+### ✨ How It Works
 
-Here’s a simple example demonstrating how components are registered and how you can interact with them using `$componentsManager`.
+When a Web Component is enhanced with `ComponentElement`, it is:
 
-1. **Create your component by extending `ComponentElement`:**
+- ✅ **Automatically registered** in `$componentsManager` when added to the DOM.
+- ✅ **Assigned a unique ID** based on its component type (e.g., `accordion-1`, `dialog-2`).
+- ✅ **Automatically unregistered** when removed from the DOM.
+
+This allows **global tracking, retrieval, and communication** between Web Components.
+
+---
+
+### 🚀 Example Usage
+
+1. **Create a Custom Component Using `ComponentElement:**
 
 ```ts
 import { ComponentElement } from '@root/src/scripts/stores/componentManager';
 
-class Foo extends ComponentElement {
+class Foo extends HTMLElement {
     constructor() {
         super();
     }
+}
 
-    connectedCallback() {
-        super.connectedCallback();
-    }
+customElements.define('c-foo', ComponentElement(Foo));
+```
 
-    disconnectedCallback() {
-        super.disconnectedCallback();
+You can extend classes other than `HTMLElement` to gain more specific attributes and behaviors. For example, extending `HTMLDetailsElement` allows you to create a custom `<details>` component while preserving its native functionality. This is made possible using the [is attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is), which enables custom elements to extend built-in ones.
+
+```ts
+class Accordion extends HTMLDetailsElement {
+    constructor() {
+        super();
     }
 }
 
-customElements.define('c-foo', Foo);
+customElements.define('c-accordion', ComponentElement(Accordion), { extends: 'details' });
+```
+
+```html
+<details is="c-accordion">
+    <summary>Click me</summary>
+    <p>This is an accordion content!</p>
+</details>
 ```
 
 2. **Access component instances from `$componentsManager`:**
 
 You can use `$componentsManager.get()` or one of the following helpers `getComponentsByPrototype()` and `getComponentsById()` to retrieve the current list of components and interact with them.
 
--   **Access all components of a specific prototype:**
+- **Access all components of a specific prototype:**
 
 ```ts
 import { getComponentsByPrototype } from '@root/src/scripts/stores/componentManager';
@@ -261,7 +282,11 @@ $allFoo.forEach(($foo) => {
 });
 ```
 
--   **Access a specific component by its `id`:**
+- **Access a specific component by its `id`:**
+
+```html
+<c-foo id="foo-1"></c-foo>
+```
 
 ```ts
 import { getComponentsById } from '@root/src/scripts/stores/componentManager';
@@ -272,7 +297,7 @@ if ($foo) {
 }
 ```
 
--   **Exclude the current instance:**
+- **Exclude the current instance:**
 
 ```ts
 import { getComponentsByPrototype } from '@root/src/scripts/stores/componentManager';
@@ -290,6 +315,6 @@ const $filteredComponents = getComponentsByPrototype('Bar', ['#exclude-me', '.ig
 
 ### Best Practices
 
--   **Always call `super.connectedCallback()` and `super.disconnectedCallback()`** in your component’s lifecycle methods to ensure proper registration/unregistration.
--   Use `id`s to uniquely identify components and interact with specific instances.
--   Take advantage of the `$componentsManager.get()` method to manage and control components centrally, especially when multiple instances of the same component type are involved.
+- **Always call `super.connectedCallback()` and `super.disconnectedCallback()`** in your component’s lifecycle methods to ensure proper registration/unregistration.
+- Use `id`s to uniquely identify components and interact with specific instances.
+- Take advantage of the `$componentsManager.get()` method to manage and control components centrally, especially when multiple instances of the same component type are involved.

--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -251,6 +251,7 @@ customElements.define('c-foo', ComponentElement(Foo, 'Foo'));
 You can extend classes other than `HTMLElement` to gain more specific attributes and behaviors. For example, extending `HTMLDetailsElement` allows you to create a custom `<details>` component while preserving its native functionality. This is made possible using the [is attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is), which enables custom elements to extend built-in ones.
 
 ```ts
+import { ComponentElement } from '@root/src/scripts/stores/componentManager';
 class Accordion extends HTMLDetailsElement {
     constructor() {
         super();

--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -245,7 +245,7 @@ class Foo extends HTMLElement {
     }
 }
 
-customElements.define('c-foo', ComponentElement(Foo));
+customElements.define('c-foo', ComponentElement(Foo, 'Foo'));
 ```
 
 You can extend classes other than `HTMLElement` to gain more specific attributes and behaviors. For example, extending `HTMLDetailsElement` allows you to create a custom `<details>` component while preserving its native functionality. This is made possible using the [is attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is), which enables custom elements to extend built-in ones.
@@ -257,7 +257,9 @@ class Accordion extends HTMLDetailsElement {
     }
 }
 
-customElements.define('c-accordion', ComponentElement(Accordion), { extends: 'details' });
+customElements.define('c-accordion', ComponentElement(Accordion, 'Accordion'), {
+    extends: 'details'
+});
 ```
 
 ```html

--- a/src/scripts/stores/componentManager.ts
+++ b/src/scripts/stores/componentManager.ts
@@ -1,18 +1,21 @@
 import { atom } from 'nanostores';
 
-export const ComponentElement = <BaseClass extends CustomElementConstructor>(Base: BaseClass) => {
+export const ComponentElement = <BaseClass extends CustomElementConstructor>(
+    Base: BaseClass,
+    className: string
+) => {
     return class extends Base {
         prototypeType: string;
 
         constructor(...args: any[]) {
             super(...args);
 
-            this.prototypeType = Base.name;
+            this.prototypeType = className;
 
             if (!this.id) {
                 const index = $componentsManagerIncrement.get() + 1;
                 $componentsManagerIncrement.set(index);
-                this.id = `${Base.name.toLowerCase()}-${index}`;
+                this.id = `${this.prototypeType.toLowerCase()}-${index}`;
             }
         }
 

--- a/src/scripts/stores/componentManager.ts
+++ b/src/scripts/stores/componentManager.ts
@@ -1,46 +1,43 @@
 import { atom } from 'nanostores';
 
-export class ComponentElement extends HTMLElement {
-    prototypeType: string;
+export const ComponentElement = <BaseClass extends CustomElementConstructor>(Base: BaseClass) => {
+    return class extends Base {
+        prototypeType: string;
 
-    constructor() {
-        super();
+        constructor(...args: any[]) {
+            super(...args);
 
-        this.prototypeType = this.constructor.name;
+            this.prototypeType = Base.name;
 
-        if (this.id === '') {
-            const index = $componentsManagerIncrement.get() + 1;
-            $componentsManagerIncrement.set(index);
-            this.id = `${this.constructor.name.toLowerCase()}-${index}`;
+            if (!this.id) {
+                const index = $componentsManagerIncrement.get() + 1;
+                $componentsManagerIncrement.set(index);
+                this.id = `${Base.name.toLowerCase()}-${index}`;
+            }
         }
-    }
 
-    // =============================================================================
-    // Lifecycle
-    // =============================================================================
-    connectedCallback() {
-        this.register();
-    }
+        connectedCallback() {
+            if (typeof (Base.prototype as any).connectedCallback === 'function') {
+                (Base.prototype as any).connectedCallback.call(this);
+            }
 
-    disconnectedCallback() {
-        this.unregister();
-    }
+            $componentsManager.set([...$componentsManager.get(), this]);
+        }
 
-    // =============================================================================
-    // Methods
-    // =============================================================================
-    register() {
-        $componentsManager.set([...$componentsManager.get(), this]);
-    }
-    unregister() {
-        $componentsManager.set(
-            $componentsManager.get().filter(($component) => $component.id !== this.id)
-        );
-    }
-}
+        disconnectedCallback() {
+            if (typeof (Base.prototype as any).disconnectedCallback === 'function') {
+                (Base.prototype as any).disconnectedCallback.call(this);
+            }
+
+            $componentsManager.set(
+                $componentsManager.get().filter(($component) => $component.id !== this.id)
+            );
+        }
+    };
+};
 
 export const $componentsManagerIncrement = atom<number>(0);
-export const $componentsManager = atom<ComponentElement[]>([]);
+export const $componentsManager = atom<InstanceType<ReturnType<typeof ComponentElement>>[]>([]);
 
 export const getComponentById = (id: string) => {
     return $componentsManager.get().find(($component) => $component.id === id);
@@ -48,7 +45,11 @@ export const getComponentById = (id: string) => {
 
 export const getComponentsByPrototype = (
     prototype: string,
-    selectorsToExclude: string[] | string | HTMLElement | ComponentElement = []
+    selectorsToExclude:
+        | string[]
+        | string
+        | HTMLElement
+        | InstanceType<ReturnType<typeof ComponentElement>> = []
 ) => {
     let excludedSelectors: string[] = [];
 
@@ -60,8 +61,8 @@ export const getComponentsByPrototype = (
         excludedSelectors = [`#${selectorsToExclude.id}`];
     }
 
-    return ($componentsManager.get() as ComponentElement[]).filter(
-        ($component: ComponentElement) => {
+    return ($componentsManager.get() as InstanceType<ReturnType<typeof ComponentElement>>[]).filter(
+        ($component: InstanceType<ReturnType<typeof ComponentElement>>) => {
             return (
                 prototype === $component.prototypeType &&
                 !excludedSelectors.some((selector: string) => $component.matches(selector))


### PR DESCRIPTION
##  Summary  
This PR introduces several improvements to the **component management system**, including:  
- **Refactoring `ComponentElement` into a mixin-style function**, making it more flexible for elements extending classes other than `HTMLElement`.  
- **Supporting native HTML element extensions** (e.g., `HTMLDialogElement`, `HTMLDetailsElement`) while keeping automatic component registration.  
- **Improving the `$componentsManager` integration** to track and manage instances dynamically.  
- **Updating documentation** to reflect these changes, including new examples and an explanation of the [`is` attribute](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#extending_builtin_html_elements).

---

## ✨ Key Changes  
✅ **Refactored `ComponentElement` into a reusable function**  
- Now allows components to extend `HTMLDialogElement`, `HTMLDetailsElement`, or any other built-in element.  
- Dynamically assigns a **unique ID** and registers/unregisters components in `$componentsManager`.  

✅ **Improved Custom Element Registration**  
- Components can now **extend native elements** and still be tracked in `$componentsManager`.  
- Uses the **`is` attribute** for built-in elements (e.g., `<details is="c-accordion">`).  

✅ **Updated Component Examples**  
- **`Dialog` component now extends `HTMLDialogElement`** while keeping full component tracking.  
- **`Accordion` extends `HTMLDetailsElement`** while retaining native behavior.  
- **All component instances are automatically managed** without manual setup.  

✅ **Enhanced Documentation**  
- **Updated `README.md`** to explain how to extend built-in elements using `ComponentElement`.  
- **Added examples** demonstrating how to track and interact with components dynamically.  
- **Linked MDN documentation** for better clarity on the `is` attribute.

## 💡 Why These Changes?  
- 🔥 **Better flexibility**: Allows extending elements other than `HTMLElement`.  
- 🔥 **Native behavior retention**: No loss of built-in functionality (e.g., `<dialog>` methods, `<details>` behavior). 
