### PR TITLE
Add lenient commit message linter with commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,36 @@
+export default {
+    rules: {
+        // Subject must exist
+        'subject-empty': [2, 'never'],
+        // Subject must contain at least three words
+        'subject-min-word-count': [2, 'always', 3],
+        // Subject must be reasonable in length
+        'subject-min-length': [2, 'always', 5],
+        'subject-max-length': [1, 'always', 100],
+        'subject-full-stop': [2, 'never', '.'],
+
+        // Optional body formatting
+        'body-leading-blank': [1, 'always'],
+        'body-max-line-length': [1, 'always', 120]
+    },
+    parserPreset: {
+        // We're not looking for any header pattern (yet)
+        parserOpts: {
+            headerPattern: /^(.*)$/,
+            headerCorrespondence: ['subject']
+        }
+    },
+
+    // Custom plugin to enforce word count
+    plugins: [
+        {
+            rules: {
+                'subject-min-word-count': ({ header }, _when = 'always', value = 3) => {
+                    const wordCount = header.trim().split(/\s+/).length;
+                    const pass = wordCount >= value;
+                    return [pass, `subject must contain at least ${value} words`];
+                }
+            }
+        }
+    ]
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,7 +6,7 @@ export default {
         'subject-min-word-count': [2, 'always', 3],
         // Subject must be reasonable in length
         'subject-min-length': [2, 'always', 5],
-        'subject-max-length': [1, 'always', 100],
+        'subject-max-length': [2, 'always', 100],
         'subject-full-stop': [2, 'never', '.'],
 
         // Optional body formatting

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "typescript": "^5.8.3"
             },
             "devDependencies": {
+                "@commitlint/cli": "^19.8.1",
                 "@locomotivemtl/postcss-helpers-functions": "^1.0.2",
                 "@tailwindcss/vite": "^4.1.4",
                 "postcss-utopia": "^1.1.0",
@@ -208,6 +209,20 @@
                 "yaml": "^2.5.0"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -258,6 +273,245 @@
                 "blob-to-buffer": "^1.2.8",
                 "cross-fetch": "^3.0.4",
                 "fontkit": "^2.0.2"
+            }
+        },
+        "node_modules/@commitlint/cli": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.8.1.tgz",
+            "integrity": "sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/format": "^19.8.1",
+                "@commitlint/lint": "^19.8.1",
+                "@commitlint/load": "^19.8.1",
+                "@commitlint/read": "^19.8.1",
+                "@commitlint/types": "^19.8.1",
+                "tinyexec": "^1.0.0",
+                "yargs": "^17.0.0"
+            },
+            "bin": {
+                "commitlint": "cli.js"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/cli/node_modules/tinyexec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+            "dev": true
+        },
+        "node_modules/@commitlint/config-validator": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+            "integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.1",
+                "ajv": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/ensure": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+            "integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.1",
+                "lodash.camelcase": "^4.3.0",
+                "lodash.kebabcase": "^4.1.1",
+                "lodash.snakecase": "^4.1.1",
+                "lodash.startcase": "^4.4.0",
+                "lodash.upperfirst": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/execute-rule": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+            "integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
+            "dev": true,
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/format": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+            "integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.1",
+                "chalk": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/is-ignored": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+            "integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.1",
+                "semver": "^7.6.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/lint": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+            "integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/is-ignored": "^19.8.1",
+                "@commitlint/parse": "^19.8.1",
+                "@commitlint/rules": "^19.8.1",
+                "@commitlint/types": "^19.8.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/load": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+            "integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/config-validator": "^19.8.1",
+                "@commitlint/execute-rule": "^19.8.1",
+                "@commitlint/resolve-extends": "^19.8.1",
+                "@commitlint/types": "^19.8.1",
+                "chalk": "^5.3.0",
+                "cosmiconfig": "^9.0.0",
+                "cosmiconfig-typescript-loader": "^6.1.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "lodash.uniq": "^4.5.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/message": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+            "integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
+            "dev": true,
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/parse": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+            "integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/types": "^19.8.1",
+                "conventional-changelog-angular": "^7.0.0",
+                "conventional-commits-parser": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/read": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+            "integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/top-level": "^19.8.1",
+                "@commitlint/types": "^19.8.1",
+                "git-raw-commits": "^4.0.0",
+                "minimist": "^1.2.8",
+                "tinyexec": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/read/node_modules/tinyexec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+            "dev": true
+        },
+        "node_modules/@commitlint/resolve-extends": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+            "integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/config-validator": "^19.8.1",
+                "@commitlint/types": "^19.8.1",
+                "global-directory": "^4.0.1",
+                "import-meta-resolve": "^4.0.0",
+                "lodash.mergewith": "^4.6.2",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/rules": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+            "integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
+            "dev": true,
+            "dependencies": {
+                "@commitlint/ensure": "^19.8.1",
+                "@commitlint/message": "^19.8.1",
+                "@commitlint/to-lines": "^19.8.1",
+                "@commitlint/types": "^19.8.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/to-lines": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+            "integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
+            "dev": true,
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/top-level": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+            "integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
+            "dev": true,
+            "dependencies": {
+                "find-up": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=v18"
+            }
+        },
+        "node_modules/@commitlint/types": {
+            "version": "19.8.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+            "integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
+            "dev": true,
+            "dependencies": {
+                "@types/conventional-commits-parser": "^5.0.0",
+                "chalk": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=v18"
             }
         },
         "node_modules/@darkroom.engineering/tempus": {
@@ -1963,6 +2217,15 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/@types/conventional-commits-parser": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.1.tgz",
+            "integrity": "sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/debug": {
             "version": "4.1.12",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2281,6 +2544,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/array-ify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+            "dev": true
         },
         "node_modules/array-iterate": {
             "version": "2.0.1",
@@ -2603,6 +2872,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/camelcase": {
@@ -2961,10 +3239,50 @@
             "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
             "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
         },
+        "node_modules/compare-func": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+            "dev": true,
+            "dependencies": {
+                "array-ify": "^1.0.0",
+                "dot-prop": "^5.1.0"
+            }
+        },
         "node_modules/confbox": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
             "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
+        },
+        "node_modules/conventional-changelog-angular": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+            "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+            "dev": true,
+            "dependencies": {
+                "compare-func": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/conventional-commits-parser": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+            "integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+            "dev": true,
+            "dependencies": {
+                "is-text-path": "^2.0.0",
+                "JSONStream": "^1.3.5",
+                "meow": "^12.0.1",
+                "split2": "^4.0.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "cli.mjs"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/cookie": {
             "version": "1.0.2",
@@ -2978,6 +3296,49 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
             "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
+        },
+        "node_modules/cosmiconfig": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "dev": true,
+            "dependencies": {
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cosmiconfig-typescript-loader": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.1.0.tgz",
+            "integrity": "sha512-tJ1w35ZRUiM5FeTzT7DtYWAFFv37ZLqSRkGi2oeCK1gPhvaWjkAtfXvLmvE1pRfxxp9aQo6ba/Pvg1dKj05D4g==",
+            "dev": true,
+            "dependencies": {
+                "jiti": "^2.4.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "cosmiconfig": ">=9",
+                "typescript": ">=5"
+            }
         },
         "node_modules/cross-fetch": {
             "version": "3.2.0",
@@ -3086,6 +3447,18 @@
             "version": "2.0.28",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
             "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+        },
+        "node_modules/dargs": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
+            "integrity": "sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/debug": {
             "version": "4.4.1",
@@ -3258,6 +3631,18 @@
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
+        "node_modules/dot-prop": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
+            "dependencies": {
+                "is-obj": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/dset": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
@@ -3337,6 +3722,15 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/environment": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -3347,6 +3741,21 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/error-ex/node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
@@ -3602,6 +4011,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/find-up": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+            "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^7.2.0",
+                "path-exists": "^5.0.0",
+                "unicorn-magic": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/flattie": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -3784,6 +4210,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/git-raw-commits": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-4.0.0.tgz",
+            "integrity": "sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==",
+            "dev": true,
+            "dependencies": {
+                "dargs": "^8.0.0",
+                "meow": "^12.0.1",
+                "split2": "^4.0.0"
+            },
+            "bin": {
+                "git-raw-commits": "cli.mjs"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/github-slugger": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -3798,6 +4241,21 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/global-directory": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "dev": true,
+            "dependencies": {
+                "ini": "4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globals": {
@@ -4112,6 +4570,31 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "dev": true,
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/import-fresh/node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/import-meta-resolve": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -4119,6 +4602,15 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/ini": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "dev": true,
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/iron-webcrypto": {
@@ -4215,6 +4707,15 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/is-obj": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-plain-obj": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
@@ -4235,6 +4736,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-text-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+            "integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+            "dev": true,
+            "dependencies": {
+                "text-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/is-wsl": {
@@ -4265,6 +4778,12 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4276,6 +4795,12 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
+        },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4285,6 +4810,31 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
             "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+        },
+        "node_modules/jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+            "dev": true,
+            "engines": [
+                "node >= 0.2.0"
+            ]
+        },
+        "node_modules/JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "dependencies": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            },
+            "bin": {
+                "JSONStream": "bin.js"
+            },
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/kleur": {
             "version": "4.1.5",
@@ -4562,6 +5112,12 @@
                 "url": "https://github.com/sponsors/antonk52"
             }
         },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
+        },
         "node_modules/lint-staged": {
             "version": "15.5.2",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
@@ -4619,6 +5175,21 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
+        "node_modules/locate-path": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+            "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^6.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/locomotive-scroll": {
             "version": "5.0.0-beta.21",
             "resolved": "https://registry.npmjs.org/locomotive-scroll/-/locomotive-scroll-5.0.0-beta.21.tgz",
@@ -4634,6 +5205,60 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "dev": true
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
+        },
+        "node_modules/lodash.kebabcase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+            "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+            "dev": true
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "node_modules/lodash.mergewith": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+            "dev": true
+        },
+        "node_modules/lodash.snakecase": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+            "dev": true
+        },
+        "node_modules/lodash.startcase": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+            "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+            "dev": true
+        },
+        "node_modules/lodash.uniq": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+            "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+            "dev": true
+        },
+        "node_modules/lodash.upperfirst": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+            "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+            "dev": true
         },
         "node_modules/log-update": {
             "version": "6.1.0",
@@ -4947,6 +5572,18 @@
             "version": "2.0.30",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+        },
+        "node_modules/meow": {
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+            "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -5560,6 +6197,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/minipass": {
             "version": "4.2.8",
             "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
@@ -5836,6 +6482,36 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/p-locate": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+            "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate/node_modules/p-limit": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^1.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-queue": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
@@ -5871,6 +6547,36 @@
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
             "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+        },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/parse-latin": {
             "version": "7.0.0",
@@ -5938,6 +6644,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+        },
+        "node_modules/path-exists": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+            "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            }
         },
         "node_modules/path-key": {
             "version": "3.1.1",
@@ -6434,6 +7149,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/restore-cursor": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -6781,6 +7505,15 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
         "node_modules/string-argv": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -6934,6 +7667,24 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/text-extensions": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+            "integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
         },
         "node_modules/tiny-inflate": {
             "version": "1.0.3",
@@ -7108,6 +7859,18 @@
             "dependencies": {
                 "pako": "^0.2.5",
                 "tiny-inflate": "^1.0.0"
+            }
+        },
+        "node_modules/unicorn-magic": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "typescript": "^5.8.3"
     },
     "devDependencies": {
+        "@commitlint/cli": "^19.8.1",
         "@locomotivemtl/postcss-helpers-functions": "^1.0.2",
         "@tailwindcss/vite": "^4.1.4",
         "postcss-utopia": "^1.1.0",
@@ -53,7 +54,8 @@
         "simple-git-hooks": "^2.13.0"
     },
     "simple-git-hooks": {
-        "pre-commit": "npm run format"
+        "pre-commit": "npm run format",
+        "commit-msg": "npx commitlint --edit"
     },
     "lint-staged": {
         "*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
# Add lenient commit message linter with [`commitlint`](https://commitlint.js.org/)

This PR introduces a lightweight and opinionated [`commitlint`](https://commitlint.js.org/) setup. The goal is to gently encourage more descriptive and meaningful commit messages, without enforcing strict Conventional Commits or requiring type prefixes like `feat:` or `fix:`.

## 🧠 Why?

Commit messages are an essential part of project history. By enforcing a few light rules, we can:

- Improve readability in tools like `git log`, GitHub, and Git clients
- Encourage better collaboration and long-term project understanding
- Avoid throwaway commits like `wip`, `qa`, or `fix` that lack context

This linter is here to help, not get in the way.

## 🔧 What it enforces

| Rule                         | Description |
|------------------------------|-------------|
| ✅ `subject` is required      | No empty messages allowed |
| ✅ Minimum 3 words            | Avoids vague one-word messages |
| ✅ Length between 5–100 chars | Enough space to be clear, but concise |
| 🚫 No trailing period         | Keeps subject lines short and to the point |
| 🆗 Body is optional           | If present, must start with a blank line and wrap lines at 120 characters |

> [!TIP]
> If 100 characters isn’t enough to describe your change, keep the subject short and clear, then use the commit body to provide additional context/information.  

## 🛠️ How it works

1. When running `git commit`, a `commit-msg` hook triggers `commitlint` on the last commit message
2. The message is validated against our config
3. If the message fails any **error-level** rules, the commit is blocked with an explanation. Otherwise, it silently goes through as usual

This is powered by [`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks), which runs [`commitlint`](https://commitlint.js.org/) automatically at commit time.

### Example

![image](https://github.com/user-attachments/assets/4a2e7a55-022b-43ff-b576-4facbeb4d354)

