### PR TITLE
Add tailwind stylesheet to prettier config to support use of custom-variables

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
     "trailingComma": "none",
     "semi": true,
     "printWidth": 100,
+    "tailwindStylesheet": "./src/styles/tailwind.css",
     "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
     "overrides": [
         {

--- a/src/components/Blocks/BlockText.astro
+++ b/src/components/Blocks/BlockText.astro
@@ -10,7 +10,7 @@ const { body } = Astro.props;
 
 {
     body && (
-        <Wysiwyg class="my-fluid-xl mx-auto max-w-3xl">
+        <Wysiwyg class="mx-auto my-fluid-xl max-w-3xl">
             <Fragment set:html={body} />
         </Wysiwyg>
     )

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,11 +46,11 @@ const FONTS: string[] = [
     <body>
         <script src="../scripts/app.ts"></script>
 
-        <div class="py-fluid-md container grid grid-cols-2">
+        <div class="container grid grid-cols-2 py-fluid-md">
             <div>
                 <Icon name="logo" />
             </div>
-            <nav class="gap-gutter flex justify-self-end">
+            <nav class="flex gap-gutter justify-self-end">
                 <a href="/">Index</a>
                 <a href="/about">About</a>
                 <a href="/post">The post</a>
@@ -63,12 +63,12 @@ const FONTS: string[] = [
             </div>
         </main>
 
-        <footer class="py-fluid-xs container flex justify-between">
+        <footer class="container flex justify-between py-fluid-xs">
             <div>
                 &copy;{new Date().getFullYear()}
             </div>
 
-            <nav class="gap-gutter flex">
+            <nav class="flex gap-gutter">
                 <a href="/">Index</a>
                 <a href="/about">About</a>
             </nav>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -11,7 +11,7 @@ import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
 
     <div class="mt-fluid-xl h-[20vh] w-full bg-black"></div>
 
-    <div class="mt-fluid-xl container">
+    <div class="container mt-fluid-xl">
         <div>
             <Image
                 src={import('@images/printer.jpg')}
@@ -22,7 +22,7 @@ import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
                 height={200}
             />
         </div>
-        <div class="gap-gutter grid grid-cols-2">
+        <div class="grid grid-cols-2 gap-gutter">
             <div>
                 <Image
                     src="https://locomotive.ca/uploads/careers/pltropics-2000w.jpg"
@@ -46,8 +46,8 @@ import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
                 />
             </div>
         </div>
-        <div class="gap-gutter grid grid-cols-12">
-            <div class="text-body-sm col-span-full md:col-span-6">
+        <div class="grid grid-cols-12 gap-gutter">
+            <div class="col-span-full text-body-sm md:col-span-6">
                 <Wysiwyg>
                     <Fragment
                         set:html={`<p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Itaque quam, nam omnis sunt laudantium tenetur obcaecati? Inventore eos vitae id repellat cum possimus voluptates nam voluptatum, assumenda, atque nesciunt debitis?</p>`}
@@ -55,7 +55,7 @@ import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
                 </Wysiwyg>
             </div>
 
-            <div class="text-body-sm col-span-full md:col-span-6">
+            <div class="col-span-full text-body-sm md:col-span-6">
                 <Wysiwyg>
                     <Fragment
                         set:html={`<p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Itaque quam, nam omnis sunt laudantium tenetur obcaecati? Inventore eos vitae id repellat cum possimus voluptates nam voluptatum, assumenda, atque nesciunt debitis?</p>`}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,8 +10,8 @@ import Accordion from '@components/Accordion/Accordion.astro';
         <h1 class="heading-h1">Welcome to the Locomotive Astro Boilerplate.</h1>
     </header>
 
-    <div class="mt-fluid-xl container">
-        <div class="gap-gutter grid grid-cols-12">
+    <div class="container mt-fluid-xl">
+        <div class="grid grid-cols-12 gap-gutter">
             <div class="text-body col-span-full md:col-span-4">
                 <Wysiwyg>
                     <Fragment
@@ -22,7 +22,7 @@ import Accordion from '@components/Accordion/Accordion.astro';
                 <Button href="/about" class="mt-fluid-sm"> Learn More </Button>
             </div>
 
-            <div class="text-body-sm col-span-full md:col-span-4">
+            <div class="col-span-full text-body-sm md:col-span-4">
                 <Wysiwyg tag="article">
                     <Fragment
                         set:html={`<p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Itaque quam, nam omnis sunt laudantium tenetur obcaecati? Inventore eos vitae id repellat cum possimus voluptates nam voluptatum, assumenda, atque nesciunt debitis?</p>`}
@@ -33,7 +33,7 @@ import Accordion from '@components/Accordion/Accordion.astro';
                 </Wysiwyg>
             </div>
 
-            <div class="text-body-sm col-span-full md:col-span-4">
+            <div class="col-span-full text-body-sm md:col-span-4">
                 <Wysiwyg>
                     <Fragment
                         set:html={`<p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Itaque quam, nam omnis sunt laudantium tenetur obcaecati? Inventore eos vitae id repellat cum possimus voluptates nam voluptatum, assumenda, atque nesciunt debitis?</p>`}
@@ -41,7 +41,7 @@ import Accordion from '@components/Accordion/Accordion.astro';
                 </Wysiwyg>
             </div>
 
-            <div class="text-body-sm col-span-full md:col-span-4">
+            <div class="col-span-full text-body-sm md:col-span-4">
                 <Accordion label="Accordion summary">
                     <Wysiwyg>
                         <Fragment
@@ -61,6 +61,6 @@ import Accordion from '@components/Accordion/Accordion.astro';
 
         <!-- Placeholder -->
         <div class="mt-fluid-xl h-[50vh] w-full bg-black opacity-50"></div>
-        <div class="mt-fluid-xl bg-grey h-[50vh] w-full"></div>
+        <div class="bg-grey mt-fluid-xl h-[50vh] w-full"></div>
     </div>
 </Layout>

--- a/src/pages/post.astro
+++ b/src/pages/post.astro
@@ -35,11 +35,11 @@ const blocks = [
         <h1 class="heading-h1">Post title</h1>
     </header>
 
-    <div class="mt-fluid-xl container">
+    <div class="container mt-fluid-xl">
         <Blocks blocks={blocks} />
 
         <!-- Placeholder -->
         <div class="mt-fluid-xl h-[50vh] w-full bg-black opacity-50"></div>
-        <div class="mt-fluid-xl bg-primary h-[50vh] w-full"></div>
+        <div class="bg-primary mt-fluid-xl h-[50vh] w-full"></div>
     </div>
 </Layout>

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -1,6 +1,6 @@
 /* Note on @utility coloring syntax https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1146#issuecomment-2637758061 */
 /* Fix issue of tailwind container injecting max-w */
 @utility container {
-    @apply px-unit-md mx-auto w-full;
+    @apply mx-auto w-full px-unit-md;
     @apply max-w-none;
 }


### PR DESCRIPTION
## Why

The `prettier-plugin-tailwindcss` wasn't reordering classes correctly when using custom variables (e.g., `text-fluid-sm`).  
This led to incorrect class sorting (e.g., custom-variable classes being pushed to the top) and allowed duplicate classes to persist.

This issue has been reported on the plugin’s GitHub repo:  
https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/357

## The fix

As suggested in this comment:  
https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/357#issuecomment-2817425689  
we can resolve the issue by including the Tailwind config file in the Prettier configuration.  
This provides the plugin with the necessary context to sort classes properly, even when custom variables are used.

--- 

> [!NOTE]
> This PR also fixes all existing occurrences of misordered classes using custom variables, which explains the number of modified files. The main change is in `.prettierrc`