### PR TITLE
Add postcss @locomotivemtl/postcss-tailwind-shortcuts v2.x

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,6 +3,7 @@ import icon from 'astro-icon';
 import tailwindcss from '@tailwindcss/vite';
 import postcssUtopia from 'postcss-utopia';
 import postcssHelpersFunctions from '@locomotivemtl/postcss-helpers-functions';
+import postcssTailwindShortcuts from '@locomotivemtl/postcss-tailwind-shortcuts';
 
 const isProd = import.meta.env.PROD;
 
@@ -12,7 +13,7 @@ export default defineConfig({
     vite: {
         css: {
             postcss: {
-                plugins: [postcssUtopia(), postcssHelpersFunctions()]
+                plugins: [postcssUtopia(), postcssHelpersFunctions(), postcssTailwindShortcuts()]
             }
         },
         esbuild: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
                 "@astrojs/check": "^0.9.4",
                 "@locomotivemtl/component-manager": "^1.0.1",
                 "@locomotivemtl/grid-helper": "^1.0.0",
-                "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.0",
                 "@swup/head-plugin": "^2.3.1",
                 "@swup/preload-plugin": "^3.2.11",
                 "@swup/scripts-plugin": "^2.1.0",
@@ -28,6 +27,7 @@
             },
             "devDependencies": {
                 "@locomotivemtl/postcss-helpers-functions": "^1.0.2",
+                "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.1",
                 "@tailwindcss/vite": "^4.1.4",
                 "postcss-utopia": "^1.1.0",
                 "prettier": "^3.5.3",
@@ -1283,9 +1283,10 @@
             }
         },
         "node_modules/@locomotivemtl/postcss-tailwind-shortcuts": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@locomotivemtl/postcss-tailwind-shortcuts/-/postcss-tailwind-shortcuts-2.0.0.tgz",
-            "integrity": "sha512-3tG0tg+ydb7DLuN3vb3B+hTli7u8kcPNjin5Bg1RNAli3txuGtaO8i+OInt3u9r7cFE5ynnSmTvE0Rl8SG77/w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@locomotivemtl/postcss-tailwind-shortcuts/-/postcss-tailwind-shortcuts-2.0.1.tgz",
+            "integrity": "sha512-TCi7ZQC3KnMuLQD9W7GQxaOSbnvJ0wfY8wvJxLv3WB/ih9az4q98L5FiQUqiMTn3kYMhKkw5p4foteLJAs1Psw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@astrojs/check": "^0.9.4",
                 "@locomotivemtl/component-manager": "^1.0.1",
                 "@locomotivemtl/grid-helper": "^1.0.0",
+                "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.0",
                 "@swup/head-plugin": "^2.3.1",
                 "@swup/preload-plugin": "^3.2.11",
                 "@swup/scripts-plugin": "^2.1.0",
@@ -1277,6 +1278,15 @@
             "resolved": "https://registry.npmjs.org/@locomotivemtl/postcss-helpers-functions/-/postcss-helpers-functions-1.0.2.tgz",
             "integrity": "sha512-goCIajTPvMHCBcV9Gn562hSvrRf6Ol91rULynzHHw4416kOEkF4Wh9aNGnfwm1V/dsAz2egv8VpadEADoLhrxA==",
             "dev": true,
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@locomotivemtl/postcss-tailwind-shortcuts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@locomotivemtl/postcss-tailwind-shortcuts/-/postcss-tailwind-shortcuts-2.0.0.tgz",
+            "integrity": "sha512-3tG0tg+ydb7DLuN3vb3B+hTli7u8kcPNjin5Bg1RNAli3txuGtaO8i+OInt3u9r7cFE5ynnSmTvE0Rl8SG77/w==",
+            "license": "MIT",
             "engines": {
                 "node": ">=20"
             }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@astrojs/check": "^0.9.4",
         "@locomotivemtl/component-manager": "^1.0.1",
         "@locomotivemtl/grid-helper": "^1.0.0",
+        "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.0",
         "@swup/head-plugin": "^2.3.1",
         "@swup/preload-plugin": "^3.2.11",
         "@swup/scripts-plugin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "@astrojs/check": "^0.9.4",
         "@locomotivemtl/component-manager": "^1.0.1",
         "@locomotivemtl/grid-helper": "^1.0.0",
-        "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.0",
         "@swup/head-plugin": "^2.3.1",
         "@swup/preload-plugin": "^3.2.11",
         "@swup/scripts-plugin": "^2.1.0",
@@ -46,6 +45,7 @@
     },
     "devDependencies": {
         "@locomotivemtl/postcss-helpers-functions": "^1.0.2",
+        "@locomotivemtl/postcss-tailwind-shortcuts": "^2.0.1",
         "@tailwindcss/vite": "^4.1.4",
         "postcss-utopia": "^1.1.0",
         "prettier": "^3.5.3",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13,12 +13,12 @@
 
 /* Global styles */
 :root {
-    --color-primary: theme-color('primary');
-    --color-secondary: theme-color('secondary');
+    --color-primary: colorCode('black');
+    --color-secondary: colorCode('white');
 }
 
 html {
-    font-family: theme('fontFamily.sans');
+    font-family: var(--font-sans);
     font-weight: 500;
 }
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -5,7 +5,7 @@
     --unit-md: 20px;
 }
 
-@theme {
+@theme static {
     --font-serif: 'Times New Roman', serif;
     --font-sans: 'Arial', sans-serif;
 


### PR DESCRIPTION
Add the `@locomotivemtl/postcss-tailwind-shortcuts` tool to enable simplified and reusable Tailwind CSS class shortcuts in our project.

[Plugin documentation](https://www.npmjs.com/package/@locomotivemtl/postcss-tailwind-shortcuts)