### PR TITLE
Refactor: migrate import aliases from @ to # prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "simple-git-hooks": "^2.13.1"
             },
             "engines": {
-                "node": "22.x",
+                "node": "24.x",
                 "npm": ">=8.0"
             }
         },
@@ -5014,7 +5014,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5035,7 +5034,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5056,7 +5054,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5077,7 +5074,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5098,7 +5094,6 @@
             "cpu": [
                 "arm"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5119,7 +5114,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5140,7 +5134,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5161,7 +5154,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5182,7 +5174,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5203,7 +5194,6 @@
             "cpu": [
                 "arm64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -5224,7 +5214,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MPL-2.0",
             "optional": true,
             "os": [

--- a/package.json
+++ b/package.json
@@ -54,19 +54,19 @@
         "simple-git-hooks": "^2.13.1"
     },
     "imports": {
-        "#classes/*": "./src/scripts/classes/*",
-        "#stores/*": "./src/scripts/stores/*",
-        "#utils/*": "./src/scripts/utils/*",
         "#assets/*": "./src/assets/*",
+        "#classes/*": "./src/scripts/classes/*",
         "#components/*": "./src/components/*",
+        "#config/*": "./config/*",
         "#data/*": "./src/data/*",
         "#layouts/*": "./src/layouts/*",
         "#pages/*": "./src/pages/*",
+        "#root/*": "./*",
         "#scripts/*": "./src/scripts/*",
-        "#styles/*": "./src/styles/*",
-        "#config/*": "./config/*",
         "#src/*": "./src/*",
-        "#root/*": "./*"
+        "#stores/*": "./src/scripts/stores/*",
+        "#styles/*": "./src/styles/*",
+        "#utils/*": "./src/scripts/utils/*"
     },
     "simple-git-hooks": {
         "pre-commit": "npm run format"

--- a/package.json
+++ b/package.json
@@ -54,18 +54,18 @@
         "simple-git-hooks": "^2.13.1"
     },
     "imports": {
+        "#classes/*": "./src/scripts/classes/*",
+        "#stores/*": "./src/scripts/stores/*",
+        "#utils/*": "./src/scripts/utils/*",
         "#assets/*": "./src/assets/*",
         "#components/*": "./src/components/*",
         "#data/*": "./src/data/*",
         "#layouts/*": "./src/layouts/*",
         "#pages/*": "./src/pages/*",
-        "#classes/*": "./src/scripts/classes/*",
-        "#utils/*": "./src/scripts/utils/*",
-        "#stores/*": "./src/scripts/stores/*",
         "#scripts/*": "./src/scripts/*",
         "#styles/*": "./src/styles/*",
-        "#src/*": "./src/*",
         "#config/*": "./config/*",
+        "#src/*": "./src/*",
         "#root/*": "./*"
     },
     "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,21 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "simple-git-hooks": "^2.13.1"
     },
+    "imports": {
+        "#assets/*": "./src/assets/*",
+        "#components/*": "./src/components/*",
+        "#data/*": "./src/data/*",
+        "#layouts/*": "./src/layouts/*",
+        "#pages/*": "./src/pages/*",
+        "#classes/*": "./src/scripts/classes/*",
+        "#utils/*": "./src/scripts/utils/*",
+        "#stores/*": "./src/scripts/stores/*",
+        "#scripts/*": "./src/scripts/*",
+        "#styles/*": "./src/styles/*",
+        "#src/*": "./src/*",
+        "#config/*": "./config/*",
+        "#root/*": "./*"
+    },
     "simple-git-hooks": {
         "pre-commit": "npm run format"
     },

--- a/src/components/Blocks/BlockImage.astro
+++ b/src/components/Blocks/BlockImage.astro
@@ -1,6 +1,6 @@
 ---
-import Image from '@components/Image/Image.astro';
-import type { Props as ImageProps } from '@components/Image/Image.astro';
+import Image from '#components/Image/Image.astro';
+import type { Props as ImageProps } from '#components/Image/Image.astro';
 
 interface Props extends ImageProps {
     // imported from Image.astro

--- a/src/components/Blocks/BlockText.astro
+++ b/src/components/Blocks/BlockText.astro
@@ -1,5 +1,5 @@
 ---
-import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
+import Wysiwyg from '#components/Wysiwyg/Wysiwyg.astro';
 
 interface Props {
     body?: string;

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -1,4 +1,4 @@
-@reference '../../styles/main.css';
+@reference '#styles/main.css';
 
 @layer components {
     :root {

--- a/src/components/Image/README.md
+++ b/src/components/Image/README.md
@@ -24,7 +24,7 @@ The Image component extends Astro’s built-in [`<Image />` (`astro:assets`)](ht
 Image will render with its original ratio and take the full width of the parent.
 
 ```astro
-<Image src={import('@images/printer.jpg')} alt="A beautiful scenery" />
+<Image src={import('#assets/images/printer.jpg')} alt="A beautiful scenery" />
 ```
 
 ### Using a Figure Tag with Caption
@@ -33,7 +33,7 @@ Wraps the image in a `<figure>` tag and includes a caption(`<figcaption>`) below
 
 ```astro
 <Image
-    src={import('@images/printer.jpg')}
+    src={import('#assets/images/printer.jpg')}
     alt="A beautiful scenery"
     tag="figure"
     caption="This is a beautiful scenery"
@@ -46,7 +46,7 @@ Specifies custom [sizes and widths](https://docs.astro.build/en/guides/images/#w
 
 ```astro
 <Image
-    src={import('@images/printer.jpg')}
+    src={import('#assets/images/printer.jpg')}
     alt="A beautiful scenery"
     sizes="(max-width: 800px) 100vw, 800px"
     widths={[400, 800, 1200]}
@@ -59,7 +59,7 @@ Adds custom CSS classes to the image component for additional styling, concatena
 
 ```astro
 <Image
-    src={import('@images/printer.jpg')}
+    src={import('#assets/images/printer.jpg')}
     alt="A beautiful scenery"
     class="c-custom-class -a-modifier"
 />
@@ -70,7 +70,12 @@ Adds custom CSS classes to the image component for additional styling, concatena
 Sets specific width and height for the image, ensuring it maintains these dimensions. Will force render the image in `object-fit: cover` based on the ratio dimension provided. You must specifiy both `width` and `height`.
 
 ```astro
-<Image src={import('@images/printer.jpg')} alt="A beautiful scenery" width="800" height="600" />
+<Image
+    src={import('#assets/images/printer.jpg')}
+    alt="A beautiful scenery"
+    width="800"
+    height="600"
+/>
 ```
 
 ### Lazy Loading
@@ -78,7 +83,7 @@ Sets specific width and height for the image, ensuring it maintains these dimens
 Uses lazy loading to defer the loading of the image until it is near the viewport, improving initial page load performance. When loaded, the `.c-image` element has the state class `is-loaded` added, allowing for styling based on state. See [Image.css](Image.css).
 
 ```astro
-<Image src={import('@images/printer.jpg')} alt="A beautiful scenery" loading="lazy" />
+<Image src={import('#assets/images/printer.jpg')} alt="A beautiful scenery" loading="lazy" />
 ```
 
 ### Locomotive Scroll
@@ -86,16 +91,16 @@ Uses lazy loading to defer the loading of the image until it is near the viewpor
 Integrates the image with Locomotive Scroll, providing smooth scrolling effects.
 
 ```astro
-<Image src={import('@images/printer.jpg')} alt="A beautiful scenery" data-scroll />
+<Image src={import('#assets/images/printer.jpg')} alt="A beautiful scenery" data-scroll />
 ```
 
 ### Static images
 
-Use this approach to include static images in your project. Images are imported with JavaScript using and import alias (`@images`). KWe recommend that local images are kept in src/ when possible so that Astro can transform, optimize and bundle them. Files in the /public directory are always served or copied into the build folder as-is, with no processing.
+Use this approach to include static images in your project. Images are imported with JavaScript using and import alias (`#images`). KWe recommend that local images are kept in src/ when possible so that Astro can transform, optimize and bundle them. Files in the /public directory are always served or copied into the build folder as-is, with no processing.
 
 ```astro
 <Image
-    src={import('@images/printer.jpg')}
+    src={import('#assets/images/printer.jpg')}
     alt="Placeholder alt"
     caption="Static image & Loading eager"
     loading="eager"

--- a/src/data/seo.ts
+++ b/src/data/seo.ts
@@ -1,4 +1,4 @@
-import metaImage from '@images/meta.png';
+import metaImage from '#assets/images/meta.png';
 
 export const defaultSeo: Seo = {
     title: 'Astro boilerplate',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,9 @@
 ---
-import '@styles/main.css';
+import '#styles/main.css';
 import { Font, type CssVariable } from 'astro:assets';
 import { SEO } from 'astro-seo';
-import { defaultSeo } from '@data/seo';
-import { getSeo } from '@scripts/utils/seo';
+import { defaultSeo } from '#data/seo';
+import { getSeo } from '#scripts/utils/seo';
 import Icon from '../components/Icon/Icon.astro';
 
 interface Props {
@@ -63,8 +63,8 @@ const FONTS: CssVariable[] = ['--custom-font-sans'];
         </footer>
 
         <script>
-            import { setViewportSize } from '@scripts/utils/setViewportSize';
-            import { $screenDebounce } from '@scripts/stores/screen';
+            import { setViewportSize } from '#scripts/utils/setViewportSize';
+            import { $screenDebounce } from '#scripts/stores/screen';
 
             // Set viewport size
             $screenDebounce.subscribe(() => {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,12 @@
 ---
 import '#styles/main.css';
+
 import { Font, type CssVariable } from 'astro:assets';
 import { SEO } from 'astro-seo';
-import { defaultSeo } from '#data/seo';
-import { getSeo } from '#scripts/utils/seo';
+
+import { defaultSeo } from '#data/seo.ts';
+import { getSeo } from '#utils/seo.ts';
+
 import Icon from '../components/Icon/Icon.astro';
 
 interface Props {
@@ -63,13 +66,9 @@ const FONTS: CssVariable[] = ['--custom-font-sans'];
         </footer>
 
         <script>
-            import { setViewportSize } from '#scripts/utils/setViewportSize';
-            import { $screenDebounce } from '#scripts/stores/screen';
-
-            // Set viewport size
-            $screenDebounce.subscribe(() => {
-                setViewportSize();
-            });
+            import { setViewportSize } from '#utils/setViewportSize';
+            import { $screenDebounce } from '#stores/screen';
+            $screenDebounce.subscribe(setViewportSize);
         </script>
     </body>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,7 @@
 ---
-import Layout from '@layouts/Layout.astro';
-import Image from '@components/Image/Image.astro';
-import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
+import Layout from '#layouts/Layout.astro';
+import Image from '#components/Image/Image.astro';
+import Wysiwyg from '#components/Wysiwyg/Wysiwyg.astro';
 ---
 
 <Layout title="About">
@@ -14,7 +14,7 @@ import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
     <div class="container mt-fluid-xl">
         <div>
             <Image
-                src={import('@images/printer.jpg')}
+                src={import('#assets/images/printer.jpg')}
                 alt="Placeholder alt"
                 caption="Static image & Loading eager"
                 loading="eager"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '@layouts/Layout.astro';
-import Button from '@components/Button/Button.astro';
-import Wysiwyg from '@components/Wysiwyg/Wysiwyg.astro';
-import Accordion from '@components/Accordion/Accordion.astro';
+import Layout from '#layouts/Layout.astro';
+import Button from '#components/Button/Button.astro';
+import Wysiwyg from '#components/Wysiwyg/Wysiwyg.astro';
+import Accordion from '#components/Accordion/Accordion.astro';
 ---
 
 <Layout title="Welcome to the Locomotive Astro Boilerplate.">

--- a/src/pages/post.astro
+++ b/src/pages/post.astro
@@ -1,7 +1,7 @@
 ---
-import Layout from '@layouts/Layout.astro';
-import Icon from '@components/Icon/Icon.astro';
-import Blocks from '@components/Blocks/Blocks.astro';
+import Layout from '#layouts/Layout.astro';
+import Icon from '#components/Icon/Icon.astro';
+import Blocks from '#components/Blocks/Blocks.astro';
 
 // Define the blocks for this post. This could be fetched from a CMS.
 const blocks = [

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,5 +1,5 @@
-import { Transitions } from '#scripts/classes/Transitions';
-import { Scroll } from '#scripts/classes/Scroll';
+import { Scroll } from '#classes/Scroll.ts';
+import { Transitions } from '#classes/Transitions.ts';
 
 // Initialize the Transitions class
 const transitions = new Transitions();

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,5 +1,5 @@
-import { Transitions } from '@scripts/classes/Transitions';
-import { Scroll } from '@scripts/classes/Scroll';
+import { Transitions } from '#scripts/classes/Transitions';
+import { Scroll } from '#scripts/classes/Scroll';
 
 // Initialize the Transitions class
 const transitions = new Transitions();

--- a/src/scripts/classes/Scroll.ts
+++ b/src/scripts/classes/Scroll.ts
@@ -1,4 +1,4 @@
-import { $scroll } from '@scripts/stores/scroll';
+import { $scroll } from '#scripts/stores/scroll';
 
 import LocomotiveScroll, {
     type lenisTargetScrollTo,

--- a/src/scripts/classes/Scroll.ts
+++ b/src/scripts/classes/Scroll.ts
@@ -1,4 +1,4 @@
-import { $scroll } from '#scripts/stores/scroll';
+import { $scroll } from '#stores/scroll.ts';
 
 import LocomotiveScroll, {
     type lenisTargetScrollTo,

--- a/src/scripts/classes/Transitions.ts
+++ b/src/scripts/classes/Transitions.ts
@@ -1,9 +1,9 @@
-import { toDash } from '@scripts/utils/string';
+import { toDash } from '#scripts/utils/string';
 import SwupHeadPlugin from '@swup/head-plugin';
 import SwupPreloadPlugin from '@swup/preload-plugin';
 import SwupScriptsPlugin from '@swup/scripts-plugin';
 import Swup from 'swup';
-import { Scroll } from '@scripts/classes/Scroll';
+import { Scroll } from '#scripts/classes/Scroll';
 
 export class Transitions {
     static readonly READY_CLASS = 'is-ready';

--- a/src/scripts/classes/Transitions.ts
+++ b/src/scripts/classes/Transitions.ts
@@ -1,9 +1,10 @@
-import { toDash } from '#scripts/utils/string';
 import SwupHeadPlugin from '@swup/head-plugin';
 import SwupPreloadPlugin from '@swup/preload-plugin';
 import SwupScriptsPlugin from '@swup/scripts-plugin';
 import Swup from 'swup';
-import { Scroll } from '#scripts/classes/Scroll';
+
+import { Scroll } from '#classes/Scroll';
+import { toDash } from '#utils/string';
 
 export class Transitions {
     static readonly READY_CLASS = 'is-ready';

--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -121,7 +121,7 @@ $scroll.listen(({ scroll, limit, velocity, direction, progress }: IScrollValues)
 
 ```ts
 import { subscribeKeys } from 'nanostores';
-import { $mediaStatus, type MediaStatus } from '@scripts/stores/deviceStatus';
+import { $mediaStatus, type MediaStatus } from '#scripts/stores/deviceStatus';
 
 subscribeKeys($mediaStatus, ['isTouchOrSmall'], (value: MediaStatus) => {
     console.log(value);

--- a/src/scripts/stores/README.md
+++ b/src/scripts/stores/README.md
@@ -121,7 +121,7 @@ $scroll.listen(({ scroll, limit, velocity, direction, progress }: IScrollValues)
 
 ```ts
 import { subscribeKeys } from 'nanostores';
-import { $mediaStatus, type MediaStatus } from '#scripts/stores/deviceStatus';
+import { $mediaStatus, type MediaStatus } from '#stores/deviceStatus';
 
 subscribeKeys($mediaStatus, ['isTouchOrSmall'], (value: MediaStatus) => {
     console.log(value);

--- a/src/scripts/stores/mouse.ts
+++ b/src/scripts/stores/mouse.ts
@@ -1,6 +1,7 @@
 import { map } from 'nanostores';
-import { $screen } from '#scripts/stores/screen';
-import { normalize, roundToDecimals } from '#scripts/utils/maths';
+
+import { $screen } from '#stores/screen';
+import { normalize, roundToDecimals } from '#utils/maths';
 
 export type MouseState = {
     x: number;

--- a/src/scripts/stores/mouse.ts
+++ b/src/scripts/stores/mouse.ts
@@ -1,6 +1,6 @@
 import { map } from 'nanostores';
-import { $screen } from '@scripts/stores/screen';
-import { normalize, roundToDecimals } from '@scripts/utils/maths';
+import { $screen } from '#scripts/stores/screen';
+import { normalize, roundToDecimals } from '#scripts/utils/maths';
 
 export type MouseState = {
     x: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,20 +4,23 @@
         "moduleResolution": "Bundler",
         "allowImportingTsExtensions": true,
         "paths": {
+            /* scripts/ folder */
+            "#classes/*": ["./src/scripts/classes/*"],
+            "#stores/*": ["./src/scripts/stores/*"],
+            "#utils/*": ["./src/scripts/utils/*"],
+
+            /* src/ folder */
             "#assets/*": ["./src/assets/*"],
             "#components/*": ["./src/components/*"],
             "#data/*": ["./src/data/*"],
             "#layouts/*": ["./src/layouts/*"],
             "#pages/*": ["./src/pages/*"],
-
-            "#classes/*": ["./src/scripts/classes/*"],
-            "#utils/*": ["./src/scripts/utils/*"],
-            "#stores/*": ["./src/scripts/stores/*"],
             "#scripts/*": ["./src/scripts/*"],
-
             "#styles/*": ["./src/styles/*"],
-            "#src/*": ["./src/*"],
+
+            /* root folder */
             "#config/*": ["./config/*"],
+            "#src/*": ["./src/*"],
             "#root/*": ["./*"]
         }
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,24 @@
 {
     "extends": "astro/tsconfigs/strict",
     "compilerOptions": {
-        "baseUrl": ".",
         "moduleResolution": "Bundler",
+        "allowImportingTsExtensions": true,
         "paths": {
-            "@root/*": ["./*"],
-            "@src/*": ["./src/*"],
-            "@components/*": ["./src/components/*"],
-            "@layouts/*": ["./src/layouts/*"],
-            "@images/*": ["./src/assets/images/*"],
-            "@pages/*": ["./src/pages/*"],
-            "@scripts/*": ["./src/scripts/*"],
-            "@styles/*": ["./src/styles/*"],
-            "@templates/*": ["./src/templates/*"],
-            "@types/*": ["types/*"],
-            "@data/*": ["./src/data/*"]
+            "#assets/*": ["./src/assets/*"],
+            "#components/*": ["./src/components/*"],
+            "#data/*": ["./src/data/*"],
+            "#layouts/*": ["./src/layouts/*"],
+            "#pages/*": ["./src/pages/*"],
+
+            "#classes/*": ["./src/scripts/classes/*"],
+            "#utils/*": ["./src/scripts/utils/*"],
+            "#stores/*": ["./src/scripts/stores/*"],
+            "#scripts/*": ["./src/scripts/*"],
+
+            "#styles/*": ["./src/styles/*"],
+            "#src/*": ["./src/*"],
+            "#config/*": ["./config/*"],
+            "#root/*": ["./*"]
         }
     },
     "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary

  - Migrate all import aliases from `@` → `#` prefix (Node.js subpath imports standard)
  - Add `imports` map to `package.json` with `#`-prefixed aliases
  - Update `tsconfig.json` paths to match — drop `baseUrl` (deprecated), add `allowImportingTsExtensions`, reorganize groupings (order matter)
  - Update all source files and docs

  ## Why

  `#` prefix = Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) standard. Avoids conflicts with scoped npm packages (`@org/pkg`). No bundler-only workarounds needed.

  Both `package.json` and `tsconfig.json` paths kept — different tools read different sources:

  | Tool | Source |
  |------|--------|
  | Vite / Astro | `package.json` imports |
  | TypeScript | `package.json` imports |
  | `eslint-plugin-import` (will be introduced in an another PR) | `tsconfig.json` paths |
  | Some IDE language servers | `tsconfig.json` paths |

  ## Test plan

  - [ ] `npm run build` passes
  - [ ] `npm run dev` — no broken imports
  - [ ] `npm run check` — no TS errors
