### PR TITLE
Add breakpoint-helper Astro integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ public/assets/images/sprite.svg
 .vercel/
 .netlify/
 .astro/
-types/gen-*
+types/generated/
 
 # virtual module bridge files (Node.js bridge)
 .virtual/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import postcssUtopia from 'postcss-utopia';
 
 /* Astro Integrations / Plugins */
 import icon from 'astro-icon';
+import breakpointsHelperAstroIntegration from './config/breakpoint-helper/breakpointsHelperAstroIntegration';
 
 /* Get server allowed hosts from .env */
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
@@ -47,6 +48,7 @@ export default defineConfig({
         }
     },
     integrations: [
+        breakpointsHelperAstroIntegration(),
         icon({
             iconDir: './src/assets/svgs'
         })

--- a/config/breakpoint-helper/README.md
+++ b/config/breakpoint-helper/README.md
@@ -46,7 +46,7 @@ const isMobile = window.innerWidth < breakpoints.md;
 
 ## TypeScript
 
-Types for the virtual module are auto-generated into `types/gen-breakpoints.d.ts` on integration setup. Each breakpoint name is documented with its `px` value in the union type for autocomplete:
+Types for the virtual module are auto-generated into `types/generated/breakpoints.d.ts` on integration setup. Each breakpoint name is documented with its `px` value in the union type for autocomplete:
 
 ```ts
 declare module 'virtual:breakpoints' {
@@ -68,7 +68,7 @@ declare module 'virtual:breakpoints' {
 At config setup:
 
 1. The CSS entry file is read and all `--breakpoint-<name>: <value>px` declarations are extracted and sorted by value ascending.
-2. `breakpointToType` writes the typed `virtual:breakpoints` declaration to `types/gen-breakpoints.d.ts`.
+2. `breakpointToType` writes the typed `virtual:breakpoints` declaration to `types/generated/breakpoints.d.ts`.
 3. A Vite virtual module plugin resolves `virtual:breakpoints` to a generated JS module exporting the `breakpoints` record and `BREAKPOINT_NAMES` array.
 
 ## Standalone Vite plugin
@@ -80,4 +80,4 @@ The integration is a thin Astro wrapper. To use in a plain Vite project, extract
 | File                                   | Purpose                                               |
 | -------------------------------------- | ----------------------------------------------------- |
 | `breakpointsHelperAstroIntegration.ts` | Entry point — CSS parsing, virtual module, Astro hook |
-| `breakpointToType.ts`                  | Generates `types/gen-breakpoints.d.ts`                |
+| `breakpointToType.ts`                  | Generates `types/generated/breakpoints.d.ts`          |

--- a/config/breakpoint-helper/README.md
+++ b/config/breakpoint-helper/README.md
@@ -1,0 +1,83 @@
+# breakpoint-helper
+
+Astro integration that reads `--breakpoint-*` CSS custom properties from Tailwind CSS and exposes them at runtime via a virtual module, with auto-generated TypeScript types.
+
+## Setup
+
+```ts
+// astro.config.ts
+import breakpointsIntegration from '#config/breakpoint-helper/breakpointsHelperAstroIntegration.ts';
+
+export default defineConfig({
+    integrations: [breakpointsIntegration()]
+});
+```
+
+### Options
+
+| Option             | Type     | Default                   | Description                                      |
+| ------------------ | -------- | ------------------------- | ------------------------------------------------ |
+| `breakpointsEntry` | `string` | `src/styles/tailwind.css` | CSS file to read `--breakpoint-*` variables from |
+
+## Source format
+
+Breakpoints are declared as CSS custom properties using the `--breakpoint-<name>` convention in pixels:
+
+```css
+/* src/styles/tailwind.css */
+:root {
+    --breakpoint-sm: 640px;
+    --breakpoint-md: 768px;
+    --breakpoint-lg: 1024px;
+    --breakpoint-xl: 1280px;
+}
+```
+
+## Usage
+
+```ts
+import { breakpoints, BREAKPOINT_NAMES } from 'virtual:breakpoints';
+
+// breakpoints.md === 768
+// BREAKPOINT_NAMES === ['sm', 'md', 'lg', 'xl']
+
+const isMobile = window.innerWidth < breakpoints.md;
+```
+
+## TypeScript
+
+Types for the virtual module are auto-generated into `types/gen-breakpoints.d.ts` on integration setup. Each breakpoint name is documented with its `px` value in the union type for autocomplete:
+
+```ts
+declare module 'virtual:breakpoints' {
+    export type BreakpointName =
+        | 'sm' /** 640px */
+        | 'md' /** 768px */
+        | 'lg' /** 1024px */
+        | 'xl' /** 1280px */;
+
+    export type BreakpointValues = Record<BreakpointName, number>;
+
+    export const breakpoints: BreakpointValues;
+    export const BREAKPOINT_NAMES: BreakpointName[];
+}
+```
+
+## How it works
+
+At config setup:
+
+1. The CSS entry file is read and all `--breakpoint-<name>: <value>px` declarations are extracted and sorted by value ascending.
+2. `breakpointToType` writes the typed `virtual:breakpoints` declaration to `types/gen-breakpoints.d.ts`.
+3. A Vite virtual module plugin resolves `virtual:breakpoints` to a generated JS module exporting the `breakpoints` record and `BREAKPOINT_NAMES` array.
+
+## Standalone Vite plugin
+
+The integration is a thin Astro wrapper. To use in a plain Vite project, extract the inline virtual module plugin into a factory and call it from `vite.config.ts`. The core helpers — `extractBreakpoints`, `generateVirtualModule`, and `breakpointToType` — contain no Astro-specific dependencies; only the hook wiring needs adjustment.
+
+## Files
+
+| File                                   | Purpose                                               |
+| -------------------------------------- | ----------------------------------------------------- |
+| `breakpointsHelperAstroIntegration.ts` | Entry point — CSS parsing, virtual module, Astro hook |
+| `breakpointToType.ts`                  | Generates `types/gen-breakpoints.d.ts`                |

--- a/config/breakpoint-helper/README.md
+++ b/config/breakpoint-helper/README.md
@@ -1,83 +1,64 @@
 # breakpoint-helper
 
-Astro integration that reads `--breakpoint-*` CSS custom properties from Tailwind CSS and exposes them at runtime via a virtual module, with auto-generated TypeScript types.
+Astro integration exposing Tailwind's `--breakpoint-*` CSS variables at runtime via a virtual module, with auto-generated types.
 
 ## Setup
 
 ```ts
 // astro.config.ts
-import breakpointsIntegration from '#config/breakpoint-helper/breakpointsHelperAstroIntegration.ts';
+// TODO: switch back to `#config/...` once PR#58 is merged
+import breakpointsIntegration from '@config/breakpoint-helper/breakpointsHelperAstroIntegration.ts';
 
 export default defineConfig({
     integrations: [breakpointsIntegration()]
 });
 ```
 
-### Options
+**Options**
 
-| Option             | Type     | Default                   | Description                                      |
-| ------------------ | -------- | ------------------------- | ------------------------------------------------ |
-| `breakpointsEntry` | `string` | `src/styles/tailwind.css` | CSS file to read `--breakpoint-*` variables from |
+| Option             | Type     | Default                   |
+| ------------------ | -------- | ------------------------- |
+| `breakpointsEntry` | `string` | `src/styles/tailwind.css` |
 
 ## Source format
 
-Breakpoints are declared as CSS custom properties using the `--breakpoint-<name>` convention in pixels:
+Declare breakpoints as `--breakpoint-<name>: <value>px` in the CSS entry (root or `@theme`):
 
 ```css
-/* src/styles/tailwind.css */
-:root {
-    --breakpoint-sm: 640px;
-    --breakpoint-md: 768px;
-    --breakpoint-lg: 1024px;
-    --breakpoint-xl: 1280px;
+@theme static {
+    --breakpoint-2xs: 340px;
+    --breakpoint-xs: 500px;
+    --breakpoint-sm: 700px;
+    --breakpoint-md: 1000px;
+    --breakpoint-lg: 1200px;
+    --breakpoint-xl: 1400px;
+    --breakpoint-2xl: 1600px;
 }
 ```
+
+> Changes require a dev server restart — generation runs at `astro:config:setup`.
 
 ## Usage
 
 ```ts
-import { breakpoints, BREAKPOINT_NAMES } from 'virtual:breakpoints';
+import {
+    $currentBreakpoint,
+    BREAKPOINT_NAMES,
+    breakpoints,
+    isBelowBreakpoint
+} from '@scripts/stores/breakpoints.ts';
+import { computed } from 'nanostores';
 
-// breakpoints.md === 768
-// BREAKPOINT_NAMES === ['sm', 'md', 'lg', 'xl']
+console.log(breakpoints.md); // 1000
+console.log(BREAKPOINT_NAMES); // ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl']
+console.log(isBelowBreakpoint('sm')); // Boolean true/false
+console.log($currentBreakpoint.get()); // current BreakpointName
 
-const isMobile = window.innerWidth < breakpoints.md;
+// React to breakpoint changes without listening to screen resize event
+const isMobile = computed($currentBreakpoint, () => isBelowBreakpoint('sm'));
+isMobile.subscribe((v) => console.log(v));
 ```
 
-## TypeScript
+## Generated Types
 
-Types for the virtual module are auto-generated into `types/generated/breakpoints.d.ts` on integration setup. Each breakpoint name is documented with its `px` value in the union type for autocomplete:
-
-```ts
-declare module 'virtual:breakpoints' {
-    export type BreakpointName =
-        | 'sm' /** 640px */
-        | 'md' /** 768px */
-        | 'lg' /** 1024px */
-        | 'xl' /** 1280px */;
-
-    export type BreakpointValues = Record<BreakpointName, number>;
-
-    export const breakpoints: BreakpointValues;
-    export const BREAKPOINT_NAMES: BreakpointName[];
-}
-```
-
-## How it works
-
-At config setup:
-
-1. The CSS entry file is read and all `--breakpoint-<name>: <value>px` declarations are extracted and sorted by value ascending.
-2. `breakpointToType` writes the typed `virtual:breakpoints` declaration to `types/generated/breakpoints.d.ts`.
-3. A Vite virtual module plugin resolves `virtual:breakpoints` to a generated JS module exporting the `breakpoints` record and `BREAKPOINT_NAMES` array.
-
-## Standalone Vite plugin
-
-The integration is a thin Astro wrapper. To use in a plain Vite project, extract the inline virtual module plugin into a factory and call it from `vite.config.ts`. The core helpers — `extractBreakpoints`, `generateVirtualModule`, and `breakpointToType` — contain no Astro-specific dependencies; only the hook wiring needs adjustment.
-
-## Files
-
-| File                                   | Purpose                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| `breakpointsHelperAstroIntegration.ts` | Entry point — CSS parsing, virtual module, Astro hook |
-| `breakpointToType.ts`                  | Generates `types/generated/breakpoints.d.ts`          |
+Types are written to `types/generated/breakpoints.d.ts` on setup. Each name in the `BreakpointName` union is documented with its `px` value for autocomplete.

--- a/config/breakpoint-helper/breakpointToType.ts
+++ b/config/breakpoint-helper/breakpointToType.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type BreakpointEntry = { name: string; value: number };
+
+/**
+ * Generate TypeScript declaration file for virtual:breakpoints module
+ */
+export function breakpointToType(breakpoints: BreakpointEntry[]): string {
+    // Generate documented union type with values shown in autocomplete
+    const documentedUnion = breakpoints
+        .map((bp) => `\n        '${bp.name}' /** ${bp.value}px */ `)
+        .join('|');
+
+    const typeString = `/**
+ * Auto-generated types for virtual:breakpoints module
+ * DO NOT EDIT MANUALLY - Run \`npm run dev\` or \`npm run build\` to regenerate
+ */
+
+declare module 'virtual:breakpoints' {
+    export type BreakpointName =${documentedUnion};
+
+    export type BreakpointValues = Record<BreakpointName, number>;
+
+    export const breakpoints: BreakpointValues;
+    export const BREAKPOINT_NAMES: BreakpointName[];
+}
+`;
+
+    const filePath = path.join(process.cwd(), 'types/gen-breakpoints.d.ts');
+    const typesDir = path.dirname(filePath);
+
+    if (!fs.existsSync(typesDir)) {
+        fs.mkdirSync(typesDir, { recursive: true });
+    }
+
+    fs.writeFileSync(filePath, typeString);
+    return typeString;
+}

--- a/config/breakpoint-helper/breakpointToType.ts
+++ b/config/breakpoint-helper/breakpointToType.ts
@@ -21,7 +21,7 @@ declare module 'virtual:breakpoints' {
     export type BreakpointName =${documentedUnion};
     export type BreakpointValues = Record<BreakpointName, number>;
     export const breakpoints: BreakpointValues;
-    export const BREAKPOINT_NAMES: BreakpointName[];
+    export const BREAKPOINT_NAMES: readonly BreakpointName[];
 }
 `;
 

--- a/config/breakpoint-helper/breakpointToType.ts
+++ b/config/breakpoint-helper/breakpointToType.ts
@@ -19,15 +19,13 @@ export function breakpointToType(breakpoints: BreakpointEntry[]): string {
 
 declare module 'virtual:breakpoints' {
     export type BreakpointName =${documentedUnion};
-
     export type BreakpointValues = Record<BreakpointName, number>;
-
     export const breakpoints: BreakpointValues;
     export const BREAKPOINT_NAMES: BreakpointName[];
 }
 `;
 
-    const filePath = path.join(process.cwd(), 'types/gen-breakpoints.d.ts');
+    const filePath = path.join(process.cwd(), 'types/generated/breakpoints.d.ts');
     const typesDir = path.dirname(filePath);
 
     if (!fs.existsSync(typesDir)) {

--- a/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
+++ b/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { AstroIntegration, AstroIntegrationLogger } from 'astro';
+import { breakpointToType } from './breakpointToType.ts';
+
+const BREAKPOINTS_ENTRY_PATH = 'src/styles/tailwind.css';
+const VIRTUAL_MODULE_ID = 'virtual:breakpoints';
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
+
+type BreakpointEntry = { name: string; value: number };
+
+/**
+ * Extract breakpoints with their values from tailwind.css CSS custom properties
+ */
+function extractBreakpoints(cssContent: string): BreakpointEntry[] {
+    const breakpointRegex = /--breakpoint-([a-zA-Z0-9-]+)\s*:\s*(\d+)px/g;
+    const breakpoints: BreakpointEntry[] = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = breakpointRegex.exec(cssContent)) !== null) {
+        const name = match[1];
+        const value = parseInt(match[2], 10);
+        if (!breakpoints.some((bp) => bp.name === name)) {
+            breakpoints.push({ name, value });
+        }
+    }
+    // Sort by value ascending
+    return breakpoints.sort((a, b) => a.value - b.value);
+}
+
+/**
+ * Generate virtual module content with breakpoint values (pure JavaScript)
+ */
+function generateVirtualModule(breakpoints: BreakpointEntry[]): string {
+    const entries = breakpoints.map((bp) => `    '${bp.name}': ${bp.value}`).join(',\n');
+    const names = breakpoints.map((bp) => `'${bp.name}'`).join(', ');
+
+    return `/**
+ * Auto-generated breakpoint values from tailwind.css
+ * This is a virtual module - import from 'virtual:breakpoints'
+ */
+
+export const breakpoints = {
+${entries}
+};
+
+export const BREAKPOINT_NAMES = [${names}];
+`;
+}
+
+/**
+ * Read CSS and extract breakpoints, generate type declaration file
+ */
+function readAndGenerateTypes(
+    rootDir: string,
+    breakpointsEntry: string,
+    logger: AstroIntegrationLogger
+): BreakpointEntry[] {
+    const cssPath = path.join(rootDir, breakpointsEntry);
+    try {
+        const cssContent = fs.readFileSync(cssPath, 'utf-8');
+        const breakpoints = extractBreakpoints(cssContent);
+
+        breakpointToType(breakpoints);
+        logger.info(`Generated types/gen-breakpoints.d.ts (${breakpoints.length} breakpoints)`);
+
+        return breakpoints;
+    } catch {
+        logger.warn('Failed to read or generate breakpoints from tailwind.css');
+        return [];
+    }
+}
+
+/**
+ * Astro integration for breakpoint types and virtual module.
+ * - Generates types/virtual-breakpoints.d.ts on dev server start and build
+ * - Provides virtual:breakpoints module for runtime access to breakpoint values
+ */
+export default function breakpointsHelperAstroIntegration(
+    breakpointsEntry: string = BREAKPOINTS_ENTRY_PATH
+): AstroIntegration {
+    let breakpoints: BreakpointEntry[] = [];
+    let rootDir: string;
+
+    return {
+        name: 'breakpoints-helper-astro-integration',
+        hooks: {
+            'astro:config:setup': ({ config, updateConfig, logger }) => {
+                rootDir = config.root.pathname;
+
+                // Generate types and extract breakpoints
+                breakpoints = readAndGenerateTypes(rootDir, breakpointsEntry, logger);
+
+                // Add minimal Vite plugin for virtual module resolution
+                updateConfig({
+                    vite: {
+                        plugins: [
+                            {
+                                name: 'breakpoints-virtual-module',
+                                resolveId(id) {
+                                    if (id === VIRTUAL_MODULE_ID) {
+                                        return RESOLVED_VIRTUAL_MODULE_ID;
+                                    }
+                                },
+                                load(id) {
+                                    if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+                                        return generateVirtualModule(breakpoints);
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                });
+            }
+        }
+    };
+}

--- a/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
+++ b/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
@@ -11,19 +11,29 @@ const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
 type BreakpointEntry = { name: string; value: number };
 
 /**
- * Extract breakpoints with their values from tailwind.css CSS custom properties
+ * Extract breakpoints with their values from tailwind.css CSS custom properties.
+ * Warns on `--breakpoint-*` declarations that are not integer-px (e.g. `1rem`,`1.5px`)
+ * since the runtime relies on integer-px values.
  */
-function extractBreakpoints(cssContent: string): BreakpointEntry[] {
-    const breakpointRegex = /--breakpoint-([a-zA-Z0-9-]+)\s*:\s*(\d+)px/g;
+function extractBreakpoints(cssContent: string, logger: AstroIntegrationLogger): BreakpointEntry[] {
+    const declarationRegex = /--breakpoint-([a-zA-Z0-9-]+)\s*:\s*([^;]+);/g;
+    const integerPxRegex = /^(\d+)px$/;
     const breakpoints: BreakpointEntry[] = [];
     let match: RegExpExecArray | null;
 
-    while ((match = breakpointRegex.exec(cssContent)) !== null) {
+    while ((match = declarationRegex.exec(cssContent)) !== null) {
         const name = match[1];
-        const value = parseInt(match[2], 10);
-        if (!breakpoints.some((bp) => bp.name === name)) {
-            breakpoints.push({ name, value });
+        const rawValue = match[2].trim();
+        const pxMatch = rawValue.match(integerPxRegex);
+
+        if (!pxMatch) {
+            logger.warn(
+                `Skipping --breakpoint-${name}: "${rawValue}" — expected an integer-px value (e.g. "700px").`
+            );
+            continue;
         }
+
+        breakpoints.push({ name, value: parseInt(pxMatch[1], 10) });
     }
     // Sort by value ascending
     return breakpoints.sort((a, b) => a.value - b.value);
@@ -41,9 +51,7 @@ function generateVirtualModule(breakpoints: BreakpointEntry[]): string {
  * This is a virtual module - import from 'virtual:breakpoints'
  */
 
-export const breakpoints = {
-${entries}
-};
+export const breakpoints = {${entries}};
 
 export const BREAKPOINT_NAMES = [${names}];
 `;
@@ -60,7 +68,7 @@ function readAndGenerateTypes(
     const cssPath = path.join(rootDir, breakpointsEntry);
     try {
         const cssContent = fs.readFileSync(cssPath, 'utf-8');
-        const breakpoints = extractBreakpoints(cssContent);
+        const breakpoints = extractBreakpoints(cssContent, logger);
 
         breakpointToType(breakpoints);
         logger.info(
@@ -68,8 +76,9 @@ function readAndGenerateTypes(
         );
 
         return breakpoints;
-    } catch {
-        logger.warn('Failed to read or generate breakpoints from tailwind.css');
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`Failed to read or generate breakpoints from ${cssPath}: ${message}`);
         return [];
     }
 }
@@ -86,7 +95,7 @@ export default function breakpointsHelperAstroIntegration(
     let rootDir: string;
 
     return {
-        name: 'breakpoints-helper-astro-integration',
+        name: 'breakpoints-helper',
         hooks: {
             'astro:config:setup': ({ config, updateConfig, logger }) => {
                 rootDir = config.root.pathname;

--- a/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
+++ b/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
@@ -51,9 +51,11 @@ function generateVirtualModule(breakpoints: BreakpointEntry[]): string {
  * This is a virtual module - import from 'virtual:breakpoints'
  */
 
-export const breakpoints = {${entries}};
+export const breakpoints = Object.freeze({
+${entries}
+});
 
-export const BREAKPOINT_NAMES = [${names}];
+export const BREAKPOINT_NAMES = Object.freeze([${names}]);
 `;
 }
 

--- a/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
+++ b/config/breakpoint-helper/breakpointsHelperAstroIntegration.ts
@@ -63,7 +63,9 @@ function readAndGenerateTypes(
         const breakpoints = extractBreakpoints(cssContent);
 
         breakpointToType(breakpoints);
-        logger.info(`Generated types/gen-breakpoints.d.ts (${breakpoints.length} breakpoints)`);
+        logger.info(
+            `Generated types/generated/breakpoints.d.ts (${breakpoints.length} breakpoints)`
+        );
 
         return breakpoints;
     } catch {

--- a/src/scripts/stores/breakpoints.ts
+++ b/src/scripts/stores/breakpoints.ts
@@ -2,15 +2,12 @@ import { computed, map } from 'nanostores';
 import { breakpoints, BREAKPOINT_NAMES, type BreakpointName } from 'virtual:breakpoints';
 
 /**
- This re-export allows other files to import everything
- from a single location (#stores/breakpoint.ts) instead
- of having to import from two different sources.
-*/
+ * This re-export allows other files to import everything
+ * from a single location (#stores/breakpoint.ts) instead
+ * of having to import from two different sources.
+ */
 export * from 'virtual:breakpoints';
 
-/**
- * Breakpoint store values
- */
 export type BreakpointsValues = {
     current: BreakpointName;
     list: typeof breakpoints;
@@ -19,9 +16,6 @@ export type BreakpointsValues = {
     isAbove: (name: BreakpointName) => boolean;
 };
 
-/**
- * Get current breakpoint based on window width
- */
 function getCurrentBreakpoint(): BreakpointName {
     const width = window.innerWidth;
     let current: BreakpointName = 'md';
@@ -34,9 +28,6 @@ function getCurrentBreakpoint(): BreakpointName {
     return current;
 }
 
-/**
- * Main breakpoints store
- */
 export const $breakpoints = map<BreakpointsValues>({
     current: getCurrentBreakpoint(),
     list: breakpoints,
@@ -45,26 +36,14 @@ export const $breakpoints = map<BreakpointsValues>({
     isAbove: isAboveBreakpoint
 });
 
-/**
- * Computed store for just the current breakpoint name
- */
 export const $currentBreakpoint = computed($breakpoints, (state) => state.current);
 
-/**
- * Media query listeners storage
- */
 const mediaQueryListeners: Map<BreakpointName, MediaQueryList> = new Map();
 
-/**
- * Handle media query change event
- */
 function handleMediaQueryChange(): void {
     $breakpoints.setKey('current', getCurrentBreakpoint());
 }
 
-/**
- * Setup media query listeners for all breakpoints
- */
 function setupMediaQueryListeners(): void {
     // Clean up existing listeners
     mediaQueryListeners.forEach((mql) => {
@@ -80,62 +59,30 @@ function setupMediaQueryListeners(): void {
     }
 }
 
-/**
- * Check if current viewport matches or exceeds a breakpoint
- */
-export function isBreakpoint(name: BreakpointName): boolean {
+/* Functions based on breakpoint names for easier usage in components */
+export function isAboveBreakpoint(name: BreakpointName): boolean {
     const mql = mediaQueryListeners.get(name);
     return mql?.matches ?? false;
 }
+export function isBelowBreakpoint(name: BreakpointName): boolean {
+    return !isAboveBreakpoint(name);
+}
+export function isBetweenBreakpoints(min: BreakpointName, max: BreakpointName): boolean {
+    return isAboveBreakpoint(min) && !isAboveBreakpoint(max);
+}
 
-/**
- * Check if current viewport is below a breakpoint
- */
+/* Functions based on breakpoint pixel values */
 export function isBelowBreakpointValue(value: number): boolean {
     return breakpoints[$currentBreakpoint.get()] < value;
 }
-
-/**
- * Check if current viewport is below a breakpoint
- */
-export function isBelowBreakpoint(name: BreakpointName): boolean {
-    return !isBreakpoint(name);
-}
-
-/**
- * Check if current viewport is above a breakpoint
- */
 export function isAboveBreakpointValue(value: number): boolean {
     return breakpoints[$currentBreakpoint.get()] > value;
 }
-
-/**
- * Check if current viewport is above a breakpoint
- */
-export function isAboveBreakpoint(name: BreakpointName): boolean {
-    return isBreakpoint(name);
-}
-
-/**
- * Check if current viewport is between two breakpoints (inclusive of min, exclusive of max)
- */
-export function isBetweenBreakpoints(min: BreakpointName, max: BreakpointName): boolean {
-    return isBreakpoint(min) && !isBreakpoint(max);
-}
-
-/**
- * Check if current viewport is between two breakpoints (inclusive of min, exclusive of max)
- */
 export function isBetweenBreakpointsValue(min: number, max: number): boolean {
     return isAboveBreakpointValue(min) && isBelowBreakpointValue(max);
 }
-
-/**
- * Get the pixel value for a breakpoint
- */
 export function getBreakpointValue(name: BreakpointName): number {
     return breakpoints[name];
 }
 
-// Initialize media query listeners
 setupMediaQueryListeners();

--- a/src/scripts/stores/breakpoints.ts
+++ b/src/scripts/stores/breakpoints.ts
@@ -4,8 +4,11 @@ import { breakpoints, BREAKPOINT_NAMES, type BreakpointName } from 'virtual:brea
 // Re-export so we can import everything from this file instead of two sources.
 export * from 'virtual:breakpoints';
 
+const isBrowser = typeof window !== 'undefined';
+
 function getCurrentBreakpoint(): BreakpointName {
     let current: BreakpointName = BREAKPOINT_NAMES[0];
+    if (!isBrowser) return current;
 
     const width = window.innerWidth;
     for (const name of BREAKPOINT_NAMES) {
@@ -57,4 +60,4 @@ export function getBreakpointValue(name: BreakpointName): number {
     return breakpoints[name];
 }
 
-setupMediaQueryListeners();
+if (isBrowser) setupMediaQueryListeners();

--- a/src/scripts/stores/breakpoints.ts
+++ b/src/scripts/stores/breakpoints.ts
@@ -1,0 +1,141 @@
+import { computed, map } from 'nanostores';
+import { breakpoints, BREAKPOINT_NAMES, type BreakpointName } from 'virtual:breakpoints';
+
+/**
+ This re-export allows other files to import everything
+ from a single location (#stores/breakpoint.ts) instead
+ of having to import from two different sources.
+*/
+export * from 'virtual:breakpoints';
+
+/**
+ * Breakpoint store values
+ */
+export type BreakpointsValues = {
+    current: BreakpointName;
+    list: typeof breakpoints;
+    keys: readonly BreakpointName[];
+    isBelow: (name: BreakpointName) => boolean;
+    isAbove: (name: BreakpointName) => boolean;
+};
+
+/**
+ * Get current breakpoint based on window width
+ */
+function getCurrentBreakpoint(): BreakpointName {
+    const width = window.innerWidth;
+    let current: BreakpointName = 'md';
+
+    for (let i = 0; i < BREAKPOINT_NAMES.length; i++) {
+        const name = BREAKPOINT_NAMES[i];
+        if (width >= breakpoints[name]) current = name;
+    }
+
+    return current;
+}
+
+/**
+ * Main breakpoints store
+ */
+export const $breakpoints = map<BreakpointsValues>({
+    current: getCurrentBreakpoint(),
+    list: breakpoints,
+    keys: BREAKPOINT_NAMES,
+    isBelow: isBelowBreakpoint,
+    isAbove: isAboveBreakpoint
+});
+
+/**
+ * Computed store for just the current breakpoint name
+ */
+export const $currentBreakpoint = computed($breakpoints, (state) => state.current);
+
+/**
+ * Media query listeners storage
+ */
+const mediaQueryListeners: Map<BreakpointName, MediaQueryList> = new Map();
+
+/**
+ * Handle media query change event
+ */
+function handleMediaQueryChange(): void {
+    $breakpoints.setKey('current', getCurrentBreakpoint());
+}
+
+/**
+ * Setup media query listeners for all breakpoints
+ */
+function setupMediaQueryListeners(): void {
+    // Clean up existing listeners
+    mediaQueryListeners.forEach((mql) => {
+        mql.removeEventListener('change', handleMediaQueryChange);
+    });
+    mediaQueryListeners.clear();
+
+    // Create media query for each breakpoint
+    for (const name of BREAKPOINT_NAMES) {
+        const mql = window.matchMedia(`(min-width: ${breakpoints[name]}px)`);
+        mediaQueryListeners.set(name, mql);
+        mql.addEventListener('change', handleMediaQueryChange);
+    }
+}
+
+/**
+ * Check if current viewport matches or exceeds a breakpoint
+ */
+export function isBreakpoint(name: BreakpointName): boolean {
+    const mql = mediaQueryListeners.get(name);
+    return mql?.matches ?? false;
+}
+
+/**
+ * Check if current viewport is below a breakpoint
+ */
+export function isBelowBreakpointValue(value: number): boolean {
+    return breakpoints[$currentBreakpoint.get()] < value;
+}
+
+/**
+ * Check if current viewport is below a breakpoint
+ */
+export function isBelowBreakpoint(name: BreakpointName): boolean {
+    return !isBreakpoint(name);
+}
+
+/**
+ * Check if current viewport is above a breakpoint
+ */
+export function isAboveBreakpointValue(value: number): boolean {
+    return breakpoints[$currentBreakpoint.get()] > value;
+}
+
+/**
+ * Check if current viewport is above a breakpoint
+ */
+export function isAboveBreakpoint(name: BreakpointName): boolean {
+    return isBreakpoint(name);
+}
+
+/**
+ * Check if current viewport is between two breakpoints (inclusive of min, exclusive of max)
+ */
+export function isBetweenBreakpoints(min: BreakpointName, max: BreakpointName): boolean {
+    return isBreakpoint(min) && !isBreakpoint(max);
+}
+
+/**
+ * Check if current viewport is between two breakpoints (inclusive of min, exclusive of max)
+ */
+export function isBetweenBreakpointsValue(min: number, max: number): boolean {
+    return isAboveBreakpointValue(min) && isBelowBreakpointValue(max);
+}
+
+/**
+ * Get the pixel value for a breakpoint
+ */
+export function getBreakpointValue(name: BreakpointName): number {
+    return breakpoints[name];
+}
+
+// Initialize media query listeners
+setupMediaQueryListeners();

--- a/src/scripts/stores/breakpoints.ts
+++ b/src/scripts/stores/breakpoints.ts
@@ -1,57 +1,29 @@
-import { computed, map } from 'nanostores';
+import { atom } from 'nanostores';
 import { breakpoints, BREAKPOINT_NAMES, type BreakpointName } from 'virtual:breakpoints';
 
-/**
- * This re-export allows other files to import everything
- * from a single location (#stores/breakpoint.ts) instead
- * of having to import from two different sources.
- */
+// Re-export so we can import everything from this file instead of two sources.
 export * from 'virtual:breakpoints';
 
-export type BreakpointsValues = {
-    current: BreakpointName;
-    list: typeof breakpoints;
-    keys: readonly BreakpointName[];
-    isBelow: (name: BreakpointName) => boolean;
-    isAbove: (name: BreakpointName) => boolean;
-};
-
 function getCurrentBreakpoint(): BreakpointName {
-    const width = window.innerWidth;
-    let current: BreakpointName = 'md';
+    let current: BreakpointName = BREAKPOINT_NAMES[0];
 
-    for (let i = 0; i < BREAKPOINT_NAMES.length; i++) {
-        const name = BREAKPOINT_NAMES[i];
+    const width = window.innerWidth;
+    for (const name of BREAKPOINT_NAMES) {
         if (width >= breakpoints[name]) current = name;
     }
 
     return current;
 }
 
-export const $breakpoints = map<BreakpointsValues>({
-    current: getCurrentBreakpoint(),
-    list: breakpoints,
-    keys: BREAKPOINT_NAMES,
-    isBelow: isBelowBreakpoint,
-    isAbove: isAboveBreakpoint
-});
-
-export const $currentBreakpoint = computed($breakpoints, (state) => state.current);
+export const $currentBreakpoint = atom<BreakpointName>(getCurrentBreakpoint());
 
 const mediaQueryListeners: Map<BreakpointName, MediaQueryList> = new Map();
 
 function handleMediaQueryChange(): void {
-    $breakpoints.setKey('current', getCurrentBreakpoint());
+    $currentBreakpoint.set(getCurrentBreakpoint());
 }
 
 function setupMediaQueryListeners(): void {
-    // Clean up existing listeners
-    mediaQueryListeners.forEach((mql) => {
-        mql.removeEventListener('change', handleMediaQueryChange);
-    });
-    mediaQueryListeners.clear();
-
-    // Create media query for each breakpoint
     for (const name of BREAKPOINT_NAMES) {
         const mql = window.matchMedia(`(min-width: ${breakpoints[name]}px)`);
         mediaQueryListeners.set(name, mql);
@@ -76,7 +48,7 @@ export function isBelowBreakpointValue(value: number): boolean {
     return breakpoints[$currentBreakpoint.get()] < value;
 }
 export function isAboveBreakpointValue(value: number): boolean {
-    return breakpoints[$currentBreakpoint.get()] > value;
+    return breakpoints[$currentBreakpoint.get()] >= value;
 }
 export function isBetweenBreakpointsValue(min: number, max: number): boolean {
     return isAboveBreakpointValue(min) && isBelowBreakpointValue(max);

--- a/src/scripts/stores/deviceStatus.ts
+++ b/src/scripts/stores/deviceStatus.ts
@@ -1,18 +1,5 @@
 import { map } from 'nanostores';
-
-// =============================================================================
-// Breakpoints
-// =============================================================================
-export type Breakpoints = {
-    sm: string;
-};
-
-const root = document.documentElement;
-const breakpointSm = getComputedStyle(root).getPropertyValue('--breakpoint-sm').trim();
-
-export const $breakpoints = map<Breakpoints>({
-    sm: breakpointSm
-});
+import { breakpoints } from './breakpoints.ts';
 
 // =============================================================================
 // MediaQueries
@@ -26,7 +13,7 @@ export type MediaQueries = {
 export const $mediaQueries = map<MediaQueries>({
     reducedMotion: `(prefers-reduced-motion: reduce)`,
     touchScreen: `(hover: none)`,
-    touchOrSmall: `(max-width: ${$breakpoints.value?.sm}), (hover: none)`
+    touchOrSmall: `(max-width: ${breakpoints.sm}px), (hover: none)`
 });
 
 // =============================================================================


### PR DESCRIPTION
## Description

Adds a custom Astro integration that reads `--breakpoint-*` CSS custom properties from Tailwind CSS and exposes them at runtime via a Vite virtual module, with auto-generated TypeScript types and a nanostores reactive store.


## Why

Media queries and reactive breakpoint detection typically require hard-coded pixel values in JS — duplicating what's already defined in CSS. This integration eliminates that: breakpoints are declared once in CSS as `--breakpoint-*` custom properties, then automatically extracted and exposed via a virtual module. No hard-coded widths in JS, no `window.resize` listeners with magic numbers – `matchMedia` handles changes efficiently and all values stay in sync with the CSS source.

## How it works

1. On `astro:config:setup`, the integration reads `src/styles/tailwind.css` and extracts all `--breakpoint-<name>: <value>px` declarations.
2. Writes auto-generated TypeScript types to `types/generated/breakpoints.d.ts` — includes JSDoc px values on union members for autocomplete.
3. Registers a Vite virtual module plugin that resolves `virtual:breakpoints` to a generated JS module.
4. The nanostores `$breakpoints` store uses `matchMedia` listeners to reactively track the current breakpoint at runtime.

## Usage

```ts
import { $currentBreakpoint, BREAKPOINT_NAMES, breakpoints, isBelowBreakpoint } from '@scripts/stores/breakpoints.ts';
import { computed } from 'nanostores';

console.log(breakpoints.md); // 1000
console.log(BREAKPOINT_NAMES); // ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl']
console.log(isBelowBreakpoint('sm')); // Boolean true/false
console.log($currentBreakpoint.get()); // current BreakpointName

// React to breakpoint changes without listening to screen resize event
const isMobile = computed($currentBreakpoint, () => isBelowBreakpoint('sm'));
isMobile.subscribe((v) => console.log(v));
```

<img width="728" height="309" alt="Capture d’écran, le 2026-05-07 à 6 00 06 p m" src="https://github.com/user-attachments/assets/a29e3244-9893-4a2a-bd71-aaf1aa03554c" />

## Testing

- Run `npm run dev` — check console for `Generated types/generated/breakpoints.d.ts (N breakpoints)` log.
- Verify `types/generated/breakpoints.d.ts` is created with correct breakpoint names and values.
- Import `@scripts/stores/breakpoints.ts` in a component and confirm values match CSS declarations.
- Resize browser window and confirm `$currentBreakpoint` updates reactively.
