### PR TITLE
Add vite defines plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ public/assets/images/sprite.svg
 .vercel/
 .netlify/
 .astro/
-types/gen-*
+types/generated/
 
 # virtual module bridge files (Node.js bridge)
 .virtual/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import postcssUtopia from 'postcss-utopia';
 
 /* Astro Integrations / Plugins */
 import icon from 'astro-icon';
+import definesAstroIntegration from './config/defines/definesAstroIntegration';
 
 /* Get server allowed hosts from .env */
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
@@ -47,6 +48,7 @@ export default defineConfig({
         }
     },
     integrations: [
+        definesAstroIntegration(),
         icon({
             iconDir: './src/assets/svgs'
         })

--- a/config/defines/README.md
+++ b/config/defines/README.md
@@ -9,24 +9,17 @@ Astro integration that injects compile-time global constants into Vite's `define
 import definesAstroIntegration from '#config/defines/definesAstroIntegration.ts';
 
 export default defineConfig({
-    integrations: [
-        definesAstroIntegration() // must come before ifdefAstroIntegration
-    ]
+    integrations: [definesAstroIntegration()]
 });
 ```
 
-> **Order matters** — register this integration before `ifdefAstroIntegration`, which reads `config.vite.define` to resolve `#if` conditions.
-
 ## Built-in defines
 
-| Constant           | Type      | Value                                                                            |
-| ------------------ | --------- | -------------------------------------------------------------------------------- |
-| `__IS_PROD__`      | `boolean` | `true` when `NODE_ENV` / `VERCEL_ENV` / `CONTEXT` is production                  |
-| `__IS_DEV__`       | `boolean` | `!__IS_PROD__`                                                                   |
-| `__DEBUG__`        | `boolean` | `!__IS_PROD__`                                                                   |
-| `__PROJECT_NAME__` | `string`  | Package name from `package.json`, uppercased and sanitised (`@`, `/`, `-` → `_`) |
+| Constant     | Type      | Value                                                            |
+| ------------ | --------- | ---------------------------------------------------------------- |
+| `__IS_DEV__` | `boolean` | `false` when `NODE_ENV` / `VERCEL_ENV` / `CONTEXT` is production |
 
-Production is detected from any of: `PROD`, `MODE=production`, `NODE_ENV=production`, or `VERCEL_ENV=production`.
+Production is detected from any of: `PROD`, `MODE=production`, `NODE_ENV=production`, `VERCEL_ENV=production`, or `CONTEXT=production`.
 
 ## Adding custom defines
 
@@ -35,58 +28,27 @@ Pass an object to merge additional constants:
 ```ts
 definesAstroIntegration({
     __API_URL__: JSON.stringify('https://api.example.com'),
-    __FEATURE_FLAG__: JSON.stringify(true)
+    __FEATURE_FLAG__: true
 });
 ```
 
-String values must be JSON-stringified (Vite performs text replacement, not injection).
+String values must be JSON-stringified (Vite performs text replacement, not injection). Booleans and numbers are stringified automatically.
 
 ## Usage in source
 
 ```ts
-/// #if __IS_DEV__
-console.log('dev only');
-/// #endif
-
-if (__IS_PROD__) {
-    // tree-shaken in dev builds
+if (__IS_DEV__) {
+    console.log('dev only');
+    // tree-shaken in production builds
 }
 ```
 
 ## TypeScript
 
-Global declarations are auto-generated into `types/gen-defines.d.ts` on integration setup. Types are inferred from the stringified values — booleans become `boolean`, strings become `string`, etc.:
+Global declarations are auto-generated into `types/generated/defines.d.ts` on integration setup. Types are inferred from the raw values via `typeof`:
 
 ```ts
-declare const __IS_PROD__: boolean;
 declare const __IS_DEV__: boolean;
-declare const __DEBUG__: boolean;
-declare const __PROJECT_NAME__: string;
+declare const __API_URL__: string;
+declare const __FEATURE_FLAG__: boolean;
 ```
-
-## Standalone Vite config
-
-The integration is a thin Astro wrapper — no Vite plugin is involved, only `vite.define`. To use the same defines in a plain Vite project:
-
-```ts
-// vite.config.ts
-import { loadEnv } from 'vite';
-
-const env = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
-const isProd = env.MODE === 'production' || env.NODE_ENV === 'production';
-
-export default defineConfig({
-    define: {
-        __IS_PROD__: JSON.stringify(isProd),
-        __IS_DEV__: JSON.stringify(!isProd),
-        __DEBUG__: JSON.stringify(!isProd)
-    }
-});
-```
-
-## Files
-
-| File                         | Purpose                                                              |
-| ---------------------------- | -------------------------------------------------------------------- |
-| `definesAstroIntegration.ts` | Entry point — resolves env, builds define map, calls `defineToType`  |
-| `../utils/defineToType.ts`   | Writes `types/gen-<filename>.d.ts` from a stringified defines record |

--- a/config/defines/README.md
+++ b/config/defines/README.md
@@ -1,0 +1,92 @@
+# defines
+
+Astro integration that injects compile-time global constants into Vite's `define` map and auto-generates matching TypeScript declarations.
+
+## Setup
+
+```ts
+// astro.config.ts
+import definesAstroIntegration from '#config/defines/definesAstroIntegration.ts';
+
+export default defineConfig({
+    integrations: [
+        definesAstroIntegration() // must come before ifdefAstroIntegration
+    ]
+});
+```
+
+> **Order matters** — register this integration before `ifdefAstroIntegration`, which reads `config.vite.define` to resolve `#if` conditions.
+
+## Built-in defines
+
+| Constant           | Type      | Value                                                                            |
+| ------------------ | --------- | -------------------------------------------------------------------------------- |
+| `__IS_PROD__`      | `boolean` | `true` when `NODE_ENV` / `VERCEL_ENV` / `CONTEXT` is production                  |
+| `__IS_DEV__`       | `boolean` | `!__IS_PROD__`                                                                   |
+| `__DEBUG__`        | `boolean` | `!__IS_PROD__`                                                                   |
+| `__PROJECT_NAME__` | `string`  | Package name from `package.json`, uppercased and sanitised (`@`, `/`, `-` → `_`) |
+
+Production is detected from any of: `PROD`, `MODE=production`, `NODE_ENV=production`, or `VERCEL_ENV=production`.
+
+## Adding custom defines
+
+Pass an object to merge additional constants:
+
+```ts
+definesAstroIntegration({
+    __API_URL__: JSON.stringify('https://api.example.com'),
+    __FEATURE_FLAG__: JSON.stringify(true)
+});
+```
+
+String values must be JSON-stringified (Vite performs text replacement, not injection).
+
+## Usage in source
+
+```ts
+/// #if __IS_DEV__
+console.log('dev only');
+/// #endif
+
+if (__IS_PROD__) {
+    // tree-shaken in dev builds
+}
+```
+
+## TypeScript
+
+Global declarations are auto-generated into `types/gen-defines.d.ts` on integration setup. Types are inferred from the stringified values — booleans become `boolean`, strings become `string`, etc.:
+
+```ts
+declare const __IS_PROD__: boolean;
+declare const __IS_DEV__: boolean;
+declare const __DEBUG__: boolean;
+declare const __PROJECT_NAME__: string;
+```
+
+## Standalone Vite config
+
+The integration is a thin Astro wrapper — no Vite plugin is involved, only `vite.define`. To use the same defines in a plain Vite project:
+
+```ts
+// vite.config.ts
+import { loadEnv } from 'vite';
+
+const env = loadEnv(process.env.NODE_ENV ?? '', process.cwd(), '');
+const isProd = env.MODE === 'production' || env.NODE_ENV === 'production';
+
+export default defineConfig({
+    define: {
+        __IS_PROD__: JSON.stringify(isProd),
+        __IS_DEV__: JSON.stringify(!isProd),
+        __DEBUG__: JSON.stringify(!isProd)
+    }
+});
+```
+
+## Files
+
+| File                         | Purpose                                                              |
+| ---------------------------- | -------------------------------------------------------------------- |
+| `definesAstroIntegration.ts` | Entry point — resolves env, builds define map, calls `defineToType`  |
+| `../utils/defineToType.ts`   | Writes `types/gen-<filename>.d.ts` from a stringified defines record |

--- a/config/defines/defineToType.ts
+++ b/config/defines/defineToType.ts
@@ -1,28 +1,28 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
-let uid = 0;
+import type { DefineValue } from './definesAstroIntegration';
 
-/**
- * Get TypeScript type from a JSON stringified value
+export function defineToType(defines: Record<string, DefineValue>): string {
+    const declarations = Object.entries(defines)
+        .map(([key, value]) => `declare const ${key}: ${typeof value};`)
+        .join('\n');
+
+    const typeString = `/**
+ * Auto-generated types for Vite defines
+ * DO NOT EDIT MANUALLY - Run \`npm run dev\` or \`npm run build\` to regenerate
  */
-function getTypeFromValue(value: string): string {
-    try {
-        const parsed = JSON.parse(value);
-        return typeof parsed;
-    } catch {
-        // If it's not valid JSON, treat as string
-        return 'string';
-    }
-}
 
-export function defineToType(
-    defines: Record<string, string> = {},
-    filename: string = `gen-types-${uid++}`
-): string {
-    const typeString = `${Object.entries(defines)
-        .map(([key, value]) => `declare const ${key}: ${getTypeFromValue(value)};`)
-        .join('\n')}`;
-    const path = `types/gen-${filename}.d.ts`;
-    fs.writeFileSync(path, typeString);
+${declarations}
+`;
+
+    const filePath = path.join(process.cwd(), 'types/generated/', `defines.d.ts`);
+    const typesDir = path.dirname(filePath);
+
+    if (!fs.existsSync(typesDir)) {
+        fs.mkdirSync(typesDir, { recursive: true });
+    }
+
+    fs.writeFileSync(filePath, typeString);
     return typeString;
 }

--- a/config/defines/defineToType.ts
+++ b/config/defines/defineToType.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+
+let uid = 0;
+
+/**
+ * Get TypeScript type from a JSON stringified value
+ */
+function getTypeFromValue(value: string): string {
+    try {
+        const parsed = JSON.parse(value);
+        return typeof parsed;
+    } catch {
+        // If it's not valid JSON, treat as string
+        return 'string';
+    }
+}
+
+export function defineToType(
+    defines: Record<string, string> = {},
+    filename: string = `gen-types-${uid++}`
+): string {
+    const typeString = `${Object.entries(defines)
+        .map(([key, value]) => `declare const ${key}: ${getTypeFromValue(value)};`)
+        .join('\n')}`;
+    const path = `types/gen-${filename}.d.ts`;
+    fs.writeFileSync(path, typeString);
+    return typeString;
+}

--- a/config/defines/defineToType.ts
+++ b/config/defines/defineToType.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { DefineValue } from './definesAstroIntegration';
+import type { Defines } from './definesAstroIntegration';
 
-export function defineToType(defines: Record<string, DefineValue>): string {
+export function defineToType(defines: Defines): string {
     const declarations = Object.entries(defines)
         .map(([key, value]) => `declare const ${key}: ${typeof value};`)
         .join('\n');

--- a/config/defines/definesAstroIntegration.ts
+++ b/config/defines/definesAstroIntegration.ts
@@ -3,7 +3,7 @@ import { loadEnv } from 'vite';
 
 import { defineToType } from './defineToType.ts';
 
-export type DefineValue = string | boolean;
+export type Defines = Record<string, any>;
 
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
 const IS_PROD =
@@ -13,11 +13,11 @@ const IS_PROD =
     ENVS?.VERCEL_ENV === 'production' || // Vercel env var
     ENVS?.CONTEXT === 'production'; // Netlify env var
 
-const DEFAULT_DEFINES: Record<string, DefineValue> = {
+const DEFAULT_DEFINES: Defines = {
     __IS_DEV__: !IS_PROD
 };
 
-function stringifyDefines(defines: Record<string, DefineValue>): Record<string, string> {
+function stringifyDefines(defines: Defines): Record<string, string> {
     return Object.fromEntries(
         Object.entries(defines).map(([key, value]) => [
             key,
@@ -26,9 +26,7 @@ function stringifyDefines(defines: Record<string, DefineValue>): Record<string, 
     );
 }
 
-export default function definesAstroIntegration(
-    defines: Record<string, DefineValue> = {}
-): AstroIntegration {
+export default function definesAstroIntegration(defines: Defines = {}): AstroIntegration {
     return {
         name: 'defines-astro-integration',
         hooks: {

--- a/config/defines/definesAstroIntegration.ts
+++ b/config/defines/definesAstroIntegration.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { AstroIntegration } from 'astro';
+import { loadEnv } from 'vite';
+
+import { defineToType } from './defineToType.ts';
+
+const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
+const IS_PROD =
+    ENVS?.PROD ||
+    ENVS?.MODE === 'production' ||
+    ENVS?.NODE_ENV === 'production' ||
+    ENVS?.VERCEL_ENV === 'production' ||
+    ENVS?.CONTEXT === 'production';
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+// Remove special characters and scope from the package name for a cleaner define
+const projectName = packageJson.name.replace(/[@/-]/g, '_').toUpperCase();
+
+type DefineValue = string | boolean | number;
+
+// Vite's define requires stringified values for text replacement
+const DEFINES: Record<string, DefineValue> = {
+    __IS_PROD__: IS_PROD,
+    __IS_DEV__: !IS_PROD,
+    __DEBUG__: !IS_PROD,
+    __PROJECT_NAME__: JSON.stringify(projectName || 'locomotive-project-name')
+};
+
+function stringifyDefines(defines: Record<string, DefineValue>): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(defines).map(([key, value]) => [
+            key,
+            typeof value === 'string' ? value : JSON.stringify(value)
+        ])
+    );
+}
+
+export default function definesAstroIntegration(
+    defines: Record<string, DefineValue> = {}
+): AstroIntegration {
+    return {
+        name: 'defines-astro-integration',
+        hooks: {
+            'astro:config:setup': ({ updateConfig, logger }) => {
+                const mergedDefines = Object.assign(DEFINES, defines);
+                const stringifiedDefines = stringifyDefines(mergedDefines);
+                defineToType(stringifiedDefines, 'defines');
+                logger.info('Generated types/gen-defines.d.ts');
+
+                updateConfig({
+                    vite: {
+                        define: stringifiedDefines
+                    }
+                });
+            }
+        }
+    };
+}

--- a/config/defines/definesAstroIntegration.ts
+++ b/config/defines/definesAstroIntegration.ts
@@ -1,31 +1,20 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
 import type { AstroIntegration } from 'astro';
 import { loadEnv } from 'vite';
 
 import { defineToType } from './defineToType.ts';
+
+export type DefineValue = string | boolean;
 
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
 const IS_PROD =
     ENVS?.PROD ||
     ENVS?.MODE === 'production' ||
     ENVS?.NODE_ENV === 'production' ||
-    ENVS?.VERCEL_ENV === 'production' ||
-    ENVS?.CONTEXT === 'production';
+    ENVS?.VERCEL_ENV === 'production' || // Vercel env var
+    ENVS?.CONTEXT === 'production'; // Netlify env var
 
-const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
-// Remove special characters and scope from the package name for a cleaner define
-const projectName = packageJson.name.replace(/[@/-]/g, '_').toUpperCase();
-
-type DefineValue = string | boolean | number;
-
-// Vite's define requires stringified values for text replacement
-const DEFINES: Record<string, DefineValue> = {
-    __IS_PROD__: IS_PROD,
-    __IS_DEV__: !IS_PROD,
-    __DEBUG__: !IS_PROD,
-    __PROJECT_NAME__: JSON.stringify(projectName || 'locomotive-project-name')
+const DEFAULT_DEFINES: Record<string, DefineValue> = {
+    __IS_DEV__: !IS_PROD
 };
 
 function stringifyDefines(defines: Record<string, DefineValue>): Record<string, string> {
@@ -44,14 +33,14 @@ export default function definesAstroIntegration(
         name: 'defines-astro-integration',
         hooks: {
             'astro:config:setup': ({ updateConfig, logger }) => {
-                const mergedDefines = Object.assign(DEFINES, defines);
-                const stringifiedDefines = stringifyDefines(mergedDefines);
-                defineToType(stringifiedDefines, 'defines');
-                logger.info('Generated types/gen-defines.d.ts');
+                const mergedDefines = Object.assign(DEFAULT_DEFINES, defines);
+                defineToType(mergedDefines);
+
+                logger.info('Generated types/generated/defines.d.ts');
 
                 updateConfig({
                     vite: {
-                        define: stringifiedDefines
+                        define: stringifyDefines(mergedDefines)
                     }
                 });
             }

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -22,3 +22,11 @@ if (__IS_DEV__) {
             console.error('Failed to load the grid helper:', error);
         });
 }
+
+if (__IS_DEV__) {
+    console.log('is dev');
+}
+
+if (!__IS_DEV__) {
+    console.log('not dev');
+}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -22,11 +22,3 @@ if (__IS_DEV__) {
             console.error('Failed to load the grid helper:', error);
         });
 }
-
-if (__IS_DEV__) {
-    console.log('is dev');
-}
-
-if (!__IS_DEV__) {
-    console.log('not dev');
-}

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -8,7 +8,7 @@ transitions.init();
 // Initialize the Scroll class
 Scroll.init();
 
-if (import.meta.env.MODE === 'development') {
+if (__IS_DEV__) {
     // Dynamically import the grid-helper only in development mode
     import('@locomotivemtl/grid-helper')
         .then(({ default: GridHelper }) => {

--- a/src/scripts/classes/Transitions.ts
+++ b/src/scripts/classes/Transitions.ts
@@ -53,7 +53,7 @@ export class Transitions {
                 }),
                 new SwupPreloadPlugin({
                     preloadHoveredLinks: true,
-                    preloadInitialPage: !import.meta.env.DEV
+                    preloadInitialPage: !__IS_DEV__
                 }),
                 new SwupScriptsPlugin()
             ]


### PR DESCRIPTION
## Summary

Introduces a custom Astro/Vite integration (`config/defines/`) that injects compile-time global constants into the Vite build. Replaces scattered `import.meta.env.*` runtime checks with tree-shakeable `__IS_DEV__`-style defines, and auto-generates TypeScript declarations so the globals are fully typed.

---

## Why

`import.meta.env.MODE === 'development'` is a runtime string comparison — bundlers can't reliably eliminate the dead branch. Vite's `define` performs text replacement at compile time, so `if (__IS_DEV__) { ... }` becomes `if (false) { ... }` in production builds and is stripped entirely by the minifier.

Additional benefits:
- **Single source of truth** — env detection logic (Vercel, Netlify `CONTEXT`, `NODE_ENV`, etc.) lives in one place instead of being duplicated across files
- **Type safety** — `types/generated/defines.d.ts` is generated automatically so TypeScript knows the type of every define
- **Extensible** — custom defines can be passed to the integration for project-specific constants

---

## How It Works

Use Vite internals defines system to populate new devines as environment variables. Can be used for other plugins if wanted, by grabbing the `define` object from the vite's hooks callback.

Default built-in defines:

| Constant | Type | Value |
|---|---|---|
| `__IS_DEV__` | `boolean` | `true` in development 

---

## Usage

Use defines directly — no import needed, they are global:

```ts
if (__IS_DEV__) {
    // stripped from production bundle
}

if (!__IS_DEV__) {
    // only included in production bundle
}
```

**Adding custom defines:**

```ts
// astro.config.ts
definesAstroIntegration({
    __API_URL__: JSON.stringify('https://api.example.com'),
    __API_VERSION__: 2,
    __FEATURE_FLAG__: true
})
```

Types are auto-generated at build/dev start in `types/generated/defines.d.ts` — no manual declaration needed.

---

## How to test

- `npm run dev` starts without errors; `types/generated/defines.d.ts` is created
-  TypeScript: no errors on `__IS_DEV__`;
- Dev: grid helper loads in the browser (confirms `__IS_DEV__ === true`)
- `npm run build` succeeds; inspect bundle output — `if (false)` blocks removed by minifier and strip the unused code;
- Custom defines passed to `definesAstroIntegration()` appear in `types/generated/defines.d.ts`
