### PR TITLE
Add ifdef preprocessor vite plugin

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import postcssUtopia from 'postcss-utopia';
 
 /* Astro Integrations / Plugins */
 import icon from 'astro-icon';
+import ifdefAstroIntegration from './config/ifdef/ifdefAstroIntegration';
 
 /* Get server allowed hosts from .env */
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
@@ -47,6 +48,7 @@ export default defineConfig({
         }
     },
     integrations: [
+        ifdefAstroIntegration(),
         icon({
             iconDir: './src/assets/svgs'
         })

--- a/config/ifdef/README.md
+++ b/config/ifdef/README.md
@@ -1,0 +1,154 @@
+# ifdef — Conditional Compilation for Astro/Vite
+
+A preprocessor that strips or reveals blocks of source code at build time based on `#if` / `#elif` / `#else` / `#endif` directives, similar to C/C++ preprocessor conditionals. Directives are written inside comments so the source remains valid before processing.
+
+---
+
+## Setup
+
+Register the integration in `astro.config.ts` **after** any integration that populates `vite.define` (e.g. `definesAstroIntegration`):
+
+```ts
+// astro.config.ts
+import ifdefAstroIntegration from '#config/ifdef/ifdefAstroIntegration.ts';
+
+export default defineConfig({
+    integrations: [
+        ifdefAstroIntegration() // reads vite.define automatically
+    ]
+});
+```
+
+The integration reads `config.vite.define` to resolve all `#if` conditions — no extra config required for defines already declared there.
+
+---
+
+## Syntax
+
+Directives are placed inside line comments (`///`) or block comments (`<!-- -->`). The comment wrapper is stripped during processing; the rest of the file is left exactly as-is.
+
+### TypeScript / JavaScript / Astro script
+
+```ts
+/// #if <condition>
+// …included when condition is true…
+/// #elif <other condition>
+// …included when other condition is true…
+/// #else
+// …included otherwise…
+/// #endif
+```
+
+### Astro / HTML templates
+
+```html
+<!-- #if <condition> -->
+<script src="analytics.js"></script>
+<!-- #endif -->
+```
+
+### Conditions
+
+Conditions are plain JavaScript expressions evaluated against the defines map. Any define declared in `vite.define` whose key is a valid JS identifier is available as a variable.
+
+```ts
+/// #if __IS_DEV__
+/// #if __IS_PROD__
+/// #if __IS_DEV__ && __USER__ == 'lisa'
+/// #if someFlag || otherFlag
+```
+
+> **Note on string defines** — Vite stores string values as JSON-stringified literals (e.g. `'"lisa"'`). The preprocessor automatically unwraps these before evaluation, so you can compare with plain string literals: `__USER__ == 'lisa'`.
+
+---
+
+## The `#code` uncomment prefix
+
+Lines prefixed with `/// #code` inside an included block are _uncommented_ (the prefix is stripped) when the block is revealed. This lets you write code that is syntactically inert while the block is excluded but becomes live code when included:
+
+```ts
+/// #if __IS_DEV__ && __USER__ == 'lisa'
+/// #code const name = "Lisa";
+/// #else
+const name = 'Locomotive';
+/// #endif
+```
+
+When the `#if` is true the revealed line becomes `const name = "Lisa";`.
+When false the `#else` branch is kept and the `#code` line is blanked out.
+
+---
+
+## Options
+
+```ts
+ifdefAstroIntegration({
+    extensions?:      string[];        // extra file extensions to process (default: see below)
+    verbose?:         boolean;         // log which branches are taken (default: false)
+    commentStyles?:   CommentStyle[];  // additional comment wrappers to recognise
+    fillWithBlanks?:  boolean;         // replace excluded lines with spaces to preserve line numbers (default: true)
+    uncommentPrefix?: string;          // prefix for #code lines (default: '/// #code')
+})
+```
+
+### Default processed extensions
+
+`.cjs` `.jsx` `.js` `.mjs` `.astro` `.ts` `.tsx`
+
+### Default comment styles
+
+| Style        | Open   | Close |
+| ------------ | ------ | ----- |
+| Line comment | `///`  | —     |
+| HTML comment | `<!--` | `-->` |
+
+---
+
+## How excluded lines are handled
+
+Excluded lines are replaced with whitespace (when `fillWithBlanks: true`, the default) to preserve source maps and line numbers. The original characters are never present in the output.
+
+---
+
+## Standalone Vite plugin
+
+The integration is a thin Astro wrapper around an inline Vite plugin. The core `parse` function has no Astro-specific dependencies. To use in a plain Vite project, extract the plugin into a factory and supply `vite.define` manually:
+
+```ts
+// vite.config.ts  (requires extracting the plugin factory first)
+import { parse } from '#config/ifdef/preprocessor.js';
+
+const defines = {
+    __IS_DEV__: JSON.stringify(process.env.NODE_ENV !== 'production')
+};
+
+export default defineConfig({
+    define: defines,
+    plugins: [
+        {
+            name: 'ifdef-vite-plugin',
+            enforce: 'pre',
+            transform(src, id) {
+                if (!/\.(ts|tsx|js|jsx|mjs|cjs)(\?|$)/.test(id) || id.includes('node_modules'))
+                    return;
+                return {
+                    code: parse(src, id, defines, false, [{ open: '///' }], true, '/// #code'),
+                    map: null
+                };
+            }
+        }
+    ]
+});
+```
+
+The only tweak needed is sourcing `vite.define` externally instead of reading it from `config.vite.define` in the Astro hook.
+
+---
+
+## Files
+
+| File                       | Purpose                                                              |
+| -------------------------- | -------------------------------------------------------------------- |
+| `ifdefAstroIntegration.ts` | Astro integration — wires up the Vite `load`/`transform` hooks       |
+| `preprocessor.ts`          | Core parser and evaluator (`parse`, `find_if_blocks`, `evaluate`, …) |
+| `preprocessor.d.ts`        | Public type declarations for `parse` and `CommentStyle`              |

--- a/config/ifdef/ifdefAstroIntegration.ts
+++ b/config/ifdef/ifdefAstroIntegration.ts
@@ -1,0 +1,82 @@
+import type { AstroIntegration } from 'astro';
+import fs from 'node:fs/promises';
+
+import { type CommentStyle, parse } from './preprocessor.js';
+
+export type { CommentStyle };
+
+export type IfdefAstroIntegrationOptions = {
+    extensions?: string[];
+    verbose?: boolean;
+    commentStyles?: CommentStyle[];
+    fillWithBlanks?: boolean;
+    uncommentPrefix?: string;
+};
+
+const DEFAULT_EXTS = ['.cjs', '.jsx', '.js', '.mjs', '.astro', '.ts', '.tsx'];
+const DEFAULT_COMMENT_STYLES: CommentStyle[] = [{ open: '///' }, { open: '<!--', close: '-->' }];
+
+export default function ifdefAstroIntegration(
+    options: IfdefAstroIntegrationOptions = {}
+): AstroIntegration {
+    const extRegex = new RegExp(
+        `(${[...DEFAULT_EXTS, ...(options.extensions ?? [])].map((e) => e.replace('.', '\\.')).join('|')})(?:\\?|$)`
+    );
+
+    const commentStyles = [...(options.commentStyles ?? []), ...DEFAULT_COMMENT_STYLES].filter(
+        (cs, index, self) =>
+            index === self.findIndex((c) => c.open === cs.open && c.close === cs.close)
+    );
+
+    return {
+        name: 'ifdef-astro-integration',
+        hooks: {
+            'astro:config:setup': ({ updateConfig, config }) => {
+                updateConfig({
+                    vite: {
+                        plugins: [
+                            {
+                                name: 'ifdef-vite-plugin',
+                                enforce: 'pre',
+
+                                async load(id) {
+                                    if (!id.endsWith('.astro') || id.includes('node_modules'))
+                                        return;
+                                    const src = await fs.readFile(id, 'utf-8');
+                                    return parse(
+                                        src,
+                                        id,
+                                        config.vite.define ?? {},
+                                        options.verbose ?? false,
+                                        commentStyles,
+                                        options.fillWithBlanks ?? true,
+                                        options.uncommentPrefix ?? '/// #code'
+                                    );
+                                },
+
+                                async transform(src, id) {
+                                    if (id.endsWith('.astro')) return;
+                                    const isNodeModule = id.includes('node_modules');
+                                    if (!extRegex.test(id) || isNodeModule) return;
+
+                                    return {
+                                        code: parse(
+                                            src,
+                                            id,
+                                            config.vite.define ?? {},
+                                            options.verbose ?? false,
+                                            commentStyles,
+                                            options.fillWithBlanks ?? true,
+                                            options.uncommentPrefix ?? '/// #code'
+                                        ),
+                                        map: null
+                                    };
+                                }
+                            }
+                        ]
+                    }
+                });
+            }
+        }
+    };
+}

--- a/config/ifdef/preprocessor.d.ts
+++ b/config/ifdef/preprocessor.d.ts
@@ -1,0 +1,24 @@
+export type CommentStyle = { open: string; close?: string };
+
+/**
+ * Processes conditional compilation directives (#if, #elif, #else, #endif)
+ * in source code using the provided defines map.
+ *
+ * @param source Source code string to process
+ * @param filePath File path shown in verbose log messages
+ * @param defs Map of define names to their values (from Vite's `define`)
+ * @param verbose Log which branches are taken to the console
+ * @param commentStyles Comment styles to recognize (e.g. `[{ open: '///' }]` or `[{ open: '<!--', close: '-->' }]`)
+ * @param fillWithBlanks Replace excluded lines with spaces (preserves line numbers)
+ * @param uncommentPrefix Prefix string marking lines to un-comment when revealed
+ * @returns Processed source code string
+ */
+export function parse(
+    source: string,
+    filePath: string,
+    defs: Record<string, unknown>,
+    verbose: boolean,
+    commentStyles: CommentStyle[],
+    fillWithBlanks: boolean,
+    uncommentPrefix: string | undefined
+): string;

--- a/config/ifdef/preprocessor.ts
+++ b/config/ifdef/preprocessor.ts
@@ -1,0 +1,336 @@
+type Range = { from: number; to: number };
+
+enum IfType {
+    If = 0,
+    Elif = 1
+}
+
+export type CommentStyle = { open: string; close?: string };
+
+let _commentStyles: CommentStyle[] = [];
+let _fillCharacter: string = ' ';
+let _uncommentPrefix: string | undefined = undefined;
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildCommentRegex(innerPattern: string): RegExp {
+    const prefixes = _commentStyles.map((s) => escapeRegex(s.open)).join('|');
+    const closes = _commentStyles.filter((s) => s.close).map((s) => escapeRegex(s.close!));
+    const closePart = closes.length > 0 ? `(?:${closes.join('|')})?` : '';
+    return new RegExp(`^[\\s]*(${prefixes})[\\s]*${innerPattern}\\s*${closePart}\\s*$`, 'g');
+}
+
+class IfBlock {
+    line_if: number;
+    line_endif: number;
+    elifs: number[];
+    line_else: number | null;
+    inner_ifs: IfBlock[];
+
+    /**
+     * @param line_if    Line index of #if
+     * @param line_endif Line index of #endif
+     * @param elifs      Line indexes of #elifs
+     * @param line_else  Line index of #else, or null
+     * @param inner_ifs  List of any IfBlocks that are contained within this IfBlock
+     */
+    constructor(
+        line_if: number,
+        line_endif: number,
+        elifs: number[] = [],
+        line_else: number | null = null,
+        inner_ifs: IfBlock[] = []
+    ) {
+        this.line_if = line_if;
+        this.line_endif = line_endif;
+        this.elifs = elifs;
+        this.line_else = line_else;
+        this.inner_ifs = inner_ifs;
+    }
+
+    getIfRange(): Range {
+        const to =
+            this.elifs.length > 0
+                ? this.elifs[0]
+                : this.line_else != null
+                  ? this.line_else
+                  : this.line_endif;
+        return { from: this.line_if, to };
+    }
+
+    getElifRange(index: number): Range {
+        if (this.elifs.length > index) {
+            const from = this.elifs[index];
+            const to =
+                this.elifs.length > index + 1
+                    ? this.elifs[index + 1]
+                    : this.line_else != null
+                      ? this.line_else
+                      : this.line_endif;
+            return { from, to };
+        } else {
+            throw `Invalid elif index '${index}', there are only ${this.elifs.length} elifs`;
+        }
+    }
+
+    getElseRange(): Range {
+        if (this.line_else != null) {
+            return { from: this.line_else, to: this.line_endif };
+        } else {
+            throw 'Cannot use elseRange when elseIx is null';
+        }
+    }
+}
+
+export function parse(
+    source: string,
+    filePath: string,
+    defs: Record<string, unknown>,
+    verbose: boolean,
+    commentStyles: CommentStyle[],
+    fillWithBlanks: boolean,
+    uncommentPrefix: string | undefined
+): string {
+    _commentStyles = commentStyles;
+    if (_commentStyles.length === 0) {
+        return source; // early exit if no comment styles are provided, as no processing can be done
+    }
+
+    if (fillWithBlanks === undefined) fillWithBlanks = false;
+    _fillCharacter = fillWithBlanks ? ' ' : '/';
+    _uncommentPrefix = uncommentPrefix;
+    // early skip check: do not process file when no '#if' are contained
+    if (source.indexOf('#if') === -1) return source;
+    const lines = source.split('\n');
+    const ifBlocks = find_if_blocks(lines);
+    for (const ifBlock of ifBlocks) {
+        apply_if(lines, ifBlock, defs, verbose, filePath);
+    }
+    return lines.join('\n');
+}
+
+function find_if_blocks(lines: string[]): IfBlock[] {
+    const blocks: IfBlock[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (match_if(lines[i])) {
+            const ifBlock = parse_if_block(lines, i);
+            blocks.push(ifBlock);
+            i = ifBlock.line_endif;
+        }
+    }
+    return blocks;
+}
+
+/**
+ * Parse #if statement at given location
+ * @param ifBlockStart Line on which the '#if' is located. (Given line MUST be start of an if-block)
+ */
+function parse_if_block(lines: string[], ifBlockStart: number): IfBlock {
+    const foundElifs: number[] = [];
+    let foundElse: number | null = null;
+    let foundEnd: number | undefined;
+    const innerIfs: IfBlock[] = [];
+    for (let i = ifBlockStart + 1; i < lines.length; i++) {
+        const curLine = lines[i];
+        const innerIfMatch = match_if(curLine);
+        if (innerIfMatch) {
+            const innerIf = parse_if_block(lines, i);
+            innerIfs.push(innerIf);
+            i = innerIf.line_endif;
+            continue;
+        }
+        const elifMatch = match_if(curLine, IfType.Elif);
+        if (elifMatch) {
+            foundElifs.push(i);
+            continue;
+        }
+        const elseMatch = match_else(curLine);
+        if (elseMatch) {
+            foundElse = i;
+            continue;
+        }
+        const endMatch = match_endif(curLine);
+        if (endMatch) {
+            foundEnd = i;
+            break;
+        }
+    }
+    if (foundEnd === undefined) {
+        throw `#if without #endif on line ${ifBlockStart + 1}`;
+    }
+    return new IfBlock(ifBlockStart, foundEnd, foundElifs, foundElse, innerIfs);
+}
+
+// group 1: comment prefix, group 2: if/elif, group 3: condition
+const ifRegex = (): RegExp => buildCommentRegex('#(if|elif)([\\s\\S]+?)');
+
+function match_if(line: string, type: IfType = IfType.If): boolean {
+    const re = ifRegex();
+    const match = re.exec(line);
+    return (
+        match !== null &&
+        ((type == IfType.If && match[2] == 'if') || (type == IfType.Elif && match[2] == 'elif'))
+    );
+}
+
+/**
+ * @param line Line to parse, must be a valid #if statement
+ * @returns The if condition
+ */
+function parse_if(line: string): string {
+    const re = ifRegex();
+    const match = re.exec(line);
+    if (match) {
+        return match[3].trim();
+    } else {
+        throw `Could not parse #if: '${line}'`;
+    }
+}
+
+function match_endif(line: string): boolean {
+    return Boolean(buildCommentRegex('#(endif)').exec(line));
+}
+
+function match_else(line: string): boolean {
+    return Boolean(buildCommentRegex('#(else)').exec(line));
+}
+
+/** Includes and excludes relevant lines based on evaluation of the provided IfBlock */
+function apply_if(
+    lines: string[],
+    ifBlock: IfBlock,
+    defs: Record<string, unknown>,
+    verbose: boolean = false,
+    filePath?: string
+): void {
+    let includeRange: Range | null = null;
+    // gets the condition and parses it
+    const ifCond = parse_if(lines[ifBlock.line_if]);
+    const ifRes = evaluate(ifCond, defs);
+    const log = (condition: string, outcome: boolean): void => {
+        if (verbose) {
+            console.log(
+                `#if block lines [${ifBlock.line_if + 1}-${ifBlock.line_endif + 1}]: Condition '${condition}' is ${
+                    outcome ? 'TRUE' : 'FALSE'
+                }. ${
+                    includeRange != null
+                        ? `Including lines [${includeRange.from + 1}-${includeRange.to + 1}]`
+                        : 'Excluding everything'
+                } (${filePath})`
+            );
+        }
+    };
+    // finds which part of the #if has to be included, all else is excluded
+    if (ifRes) {
+        // include the #if body
+        includeRange = ifBlock.getIfRange();
+        log(ifCond, true);
+    } else {
+        // if there are #elif checks if one has to be included
+        for (let elifIx = 0; elifIx < ifBlock.elifs.length; elifIx++) {
+            const elifLine = lines[ifBlock.elifs[elifIx]];
+            const elifCond = parse_if(elifLine);
+            const elifRes = evaluate(elifCond, defs);
+            if (elifRes) {
+                // include #elif
+                includeRange = ifBlock.getElifRange(elifIx);
+                log(elifCond, true);
+                break;
+            }
+        }
+        // if no #elif are found then goes to #else branch
+        if (includeRange == null) {
+            if (ifBlock.line_else != null) {
+                includeRange = ifBlock.getElseRange();
+            }
+            log(ifCond, false);
+        }
+    }
+    // blanks everything except the part that has to be included
+    if (includeRange != null) {
+        blank_code(lines, ifBlock.line_if, includeRange.from); // blanks: #if ... "from"
+        blank_code(lines, includeRange.to, ifBlock.line_endif); // blanks: "to" ... #endif
+        reveal_code(lines, includeRange.from, includeRange.to); // reveal: "from" ... "to"
+    } else {
+        blank_code(lines, ifBlock.line_if, ifBlock.line_endif); // blanks: #if ... #endif
+    }
+    // apply to inner #if blocks that have not already been erased
+    for (const innerIf of ifBlock.inner_ifs) {
+        if (
+            includeRange != null &&
+            innerIf.line_if >= includeRange.from &&
+            innerIf.line_if <= includeRange.to
+        ) {
+            apply_if(lines, innerIf, defs, verbose);
+        }
+    }
+}
+
+/**
+ * @returns true if block has to be preserved
+ */
+function evaluate(condition: string, defs: Record<string, unknown>): boolean {
+    const code = `return (${condition}) ? true : false;`;
+    // Keys like 'import.meta.env.DEV' are not valid JS identifiers and cannot be used as function params
+    const validEntries = Object.entries(defs).filter(([k]) => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(k));
+    const args = validEntries.map(([k]) => k);
+    const vals = validEntries.map(([, v]) => {
+        if (typeof v === 'string') {
+            try {
+                return JSON.parse(v);
+            } catch {
+                return v;
+            }
+        }
+        return v;
+    });
+    let result: boolean;
+    try {
+        const f = new Function(...args, code);
+        result = f(...vals);
+        // console.log(`evaluation of (${condition}) === ${result}`);
+    } catch (error) {
+        throw `error evaluation #if condition(${condition}): ${error}`;
+    }
+    return result;
+}
+
+function blank_code(lines: string[], start: number, end: number): void {
+    for (let t = start; t <= end; t++) {
+        const len = lines[t].length;
+        const lastChar = lines[t].charAt(len - 1);
+        const windowsTermination = lastChar === '\r';
+        if (len === 0) {
+            lines[t] = '';
+        } else if (len === 1) {
+            lines[t] = windowsTermination ? '\r' : ' ';
+        } else if (len === 2) {
+            lines[t] = windowsTermination ? ' \r' : _fillCharacter.repeat(2);
+        } else {
+            lines[t] = windowsTermination
+                ? _fillCharacter.repeat(len - 1) + '\r'
+                : _fillCharacter.repeat(len);
+        }
+    }
+}
+
+function reveal_code(lines: string[], start: number, end: number): void {
+    // early exit if no prefix is specified
+    if (_uncommentPrefix == undefined) return;
+    // optionally strip closing comment suffix (e.g. ' -->' for HTML comments)
+    const closes = _commentStyles.filter((s) => s.close).map((s) => escapeRegex(s.close!));
+    const closePart = closes.length > 0 ? `(?:\\s*(?:${closes.join('|')}))?` : '';
+    const regex = new RegExp(
+        `^(?<before>\\s*${escapeRegex(_uncommentPrefix)})(?<line>.*?)\\s*${closePart}\\s*$`
+    );
+
+    // replace lines that match the uncomment prefix
+    for (let t = start; t <= end; t++) {
+        const r = regex.exec(lines[t]);
+        if (r !== null && r.groups !== undefined) {
+            lines[t] = ' '.repeat(r.groups.before.length) + r.groups.line;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `#if` / `#elif` / `#else` / `#endif` preprocessor as an Astro/Vite integration. Directives are written inside comments so source files remain syntactically valid before processing. At build/dev time the Vite `load`/`transform` hooks strip excluded blocks entirely, before Vite parses or type-checks the file.

This is a companion to PR #61's `definesAstroIntegration` — it reads `config.vite.define` automatically and evaluates `#if` conditions against those defines.

**Changed files:**
- `config/ifdef/ifdefAstroIntegration.ts` *(new)*
- `config/ifdef/preprocessor.ts` *(new)*
- `config/ifdef/preprocessor.d.ts` *(new)*
- `config/ifdef/README.md` *(new)*
- `astro.config.ts` *(modified)*

---

## Why

Vite `define` works at the expression level: it replaces identifiers, and the minifier removes the dead branch afterward. Two things it cannot do:

1. **Astro template HTML** — `<!-- #if __IS_DEV__ -->` has no Vite-define equivalent; template markup has no JS expression slot for dead-code elimination.
2. **Parser-visible code** — even with defines, excluded branches are still parsed and type-checked. The `#ifdef` preprocessor removes text before Vite sees it, so invalid-in-context code in inactive branches never causes errors.

The `/// #code` uncomment feature also lets you write syntactically inert lines that become live code when a block is revealed — useful for code that references symbols only available in certain environments.

---

## How It Works

`ifdefAstroIntegration` registers an inline Vite plugin via `astro:config:setup`. The plugin uses `load` for `.astro` files (so Astro's own `transform` receives already-processed source) and `transform` for everything else. Both call `parse()` in `preprocessor.ts`.

`parse()` is a pure text preprocessor — no AST. Splits on `\n`, builds an `IfBlock` tree, evaluates each condition with `new Function(...defineKeys, condition)` against `config.vite.define`, then blanks excluded lines (preserving line numbers) and strips the `/// #code` prefix from revealed lines.

---

## Code Changes

### `config/ifdef/ifdefAstroIntegration.ts` *(new)*

```ts
export type IfdefAstroIntegrationOptions = {
    extensions?: string[];       // extra file extensions to process
    verbose?: boolean;           // log which branches are taken
    commentStyles?: CommentStyle[]; // additional comment wrappers
    fillWithBlanks?: boolean;    // preserve line numbers (default: true)
    uncommentPrefix?: string;    // prefix for #code lines (default: '/// #code')
};

export default function ifdefAstroIntegration(
    options: IfdefAstroIntegrationOptions = {}
): AstroIntegration
```

### `config/ifdef/preprocessor.ts` *(new)*

```ts
export type CommentStyle = { open: string; close?: string };

export function parse(
    source: string,
    filePath: string,
    defs: Record<string, unknown>,
    verbose: boolean,
    commentStyles: CommentStyle[],
    fillWithBlanks: boolean,
    uncommentPrefix: string | undefined
): string
```

### `astro.config.ts`

```diff
+ import ifdefAstroIntegration from './config/ifdef/ifdefAstroIntegration';

  integrations: [
+     ifdefAstroIntegration(),
      icon({ iconDir: './src/assets/svgs' })
  ],
```

---

## Usage

Register **after** `definesAstroIntegration` so `config.vite.define` is already populated:

```ts
// astro.config.ts
import definesAstroIntegration from './config/defines/definesAstroIntegration';
import ifdefAstroIntegration from './config/ifdef/ifdefAstroIntegration';

integrations: [
    definesAstroIntegration(),
    ifdefAstroIntegration(),
]
```

**TypeScript / JS files:**

```ts
/// #if __IS_DEV__
import('@locomotivemtl/grid-helper')
    .then(({ default: GridHelper }) => {
        new GridHelper({
            columns: 'var(--grid-columns)',
            gutterWidth: `var(--spacing-gutter)`,
            marginWidth: `var(--spacing-gutter)`
        });
    })
    .catch((error) => {
    console.error('Failed to load the grid helper:', error);
    });
/// #endif

/// #if __IS_DEV__
/// #code const label = 'dev';
/// #else
const label = 'prod';
/// #endif
```

**Astro templates:**

```html
<!-- #if __IS_DEV__ -->
<script src="/debug-toolbar.js"></script>
<!-- #endif -->

<!-- #if __IS_PROD__ -->
<script defer src="/analytics.js"></script>
<!-- #endif -->
```

**With verbose logging:**

```ts
ifdefAstroIntegration({ verbose: true })
```

---

## Testing

- [ ] `npm run dev` starts without errors; `/// #if __IS_DEV__` block is present in the served output
- [ ] `npm run build` succeeds; `/// #if __IS_DEV__` block is absent in `dist/` output
- [ ] Astro template `<!-- #if __IS_PROD__ -->` blocks are stripped in dev, present in build
- [ ] `verbose: true` logs condition results per file to the console
- [ ] `/// #code` lines are stripped of their prefix when their block is included
- [ ] Excluded lines are blanked (not deleted), preserving line numbers in source maps
- [ ] TypeScript: no errors when inactive branch references a symbol not available in current env
