### PR TITLE
Add postcss-helpers Astro integration

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import postcssUtopia from 'postcss-utopia';
 
 /* Astro Integrations / Plugins */
 import icon from 'astro-icon';
+import postCssProcessorsHelpersIntegration from './config/postcss-helpers/postCssProcessorsHelpersIntegration';
 
 /* Get server allowed hosts from .env */
 const ENVS = loadEnv(process.env.NODE_ENV as string, process.cwd(), '');
@@ -47,6 +48,7 @@ export default defineConfig({
         }
     },
     integrations: [
+        postCssProcessorsHelpersIntegration(),
         icon({
             iconDir: './src/assets/svgs'
         })

--- a/config/postcss-helpers/README.md
+++ b/config/postcss-helpers/README.md
@@ -1,0 +1,36 @@
+# postcss-helpers
+
+Astro integration that registers `@locomotivemtl/postcss-helpers-functions` as a PostCSS plugin and exposes its helpers at runtime via a virtual module.
+
+## Setup
+
+```ts
+// astro.config.ts
+import postCssProcessorsIntegration from '#config/postcss-helpers/postcss-integration.ts';
+
+export default defineConfig({
+    integrations: [postCssProcessorsIntegration()]
+});
+```
+
+The integration registers the PostCSS plugin and the virtual module. Available helpers are defined by `@locomotivemtl/postcss-helpers-functions`.
+
+## Virtual module — `virtual:postcss-processors`
+
+Exposes a `processStyle` function for applying the same transformations at runtime in JS/TS:
+
+```ts
+import { processStyle } from 'virtual:postcss-processors';
+
+const result = processStyle('width: dvh(100)');
+// → 'width: calc(100 * var(--dvh, 1dvh))'
+```
+
+TypeScript types for this module live in `types/gen-postcss-processors.d.ts`.
+
+## Files
+
+| File                     | Purpose                                                       |
+| ------------------------ | ------------------------------------------------------------- |
+| `postcss-integration.ts` | Astro entry point — registers PostCSS plugin + virtual module |
+| `virtual-module.ts`      | Generates virtual module JS code from the helpers list        |

--- a/config/postcss-helpers/postCssProcessorsHelpersIntegration.ts
+++ b/config/postcss-helpers/postCssProcessorsHelpersIntegration.ts
@@ -1,0 +1,57 @@
+import type { AstroIntegration } from 'astro';
+
+import postcssHelpersFunctions from '@locomotivemtl/postcss-helpers-functions';
+
+import { postcssHelpersToType } from './postcssHelpersToType';
+import { generateVirtualModuleCode, type Helper } from './virtual-module';
+
+type PostcssHelpersFunctionsPlugin = ReturnType<typeof postcssHelpersFunctions> & {
+    helpers: Helper[];
+    regex: RegExp;
+};
+
+const VIRTUAL_MODULE_ID = 'virtual:postcss-processors';
+const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
+
+export default function postCssProcessorsHelpersIntegration(): AstroIntegration {
+    const plugin = postcssHelpersFunctions() as PostcssHelpersFunctionsPlugin;
+
+    return {
+        name: 'postcss-processors',
+        hooks: {
+            'astro:config:setup': ({ config, updateConfig, logger }) => {
+                const rootDir = config.root.pathname;
+                postcssHelpersToType(rootDir);
+                logger.info('Generated types/gen-postcss-processors.d.ts');
+
+                updateConfig({
+                    vite: {
+                        css: {
+                            postcss: {
+                                plugins: [plugin]
+                            }
+                        },
+                        plugins: [
+                            {
+                                name: 'postcss-processors',
+                                resolveId(id: string) {
+                                    if (id === VIRTUAL_MODULE_ID) {
+                                        return RESOLVED_VIRTUAL_MODULE_ID;
+                                    }
+                                },
+                                load(id: string) {
+                                    if (id === RESOLVED_VIRTUAL_MODULE_ID) {
+                                        return generateVirtualModuleCode(
+                                            plugin.helpers,
+                                            plugin.regex
+                                        );
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                });
+            }
+        }
+    };
+}

--- a/config/postcss-helpers/postcssHelpersToType.ts
+++ b/config/postcss-helpers/postcssHelpersToType.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function postcssHelpersToType(rootDir: string): void {
+    const typesDir = path.join(rootDir, 'types');
+
+    if (!fs.existsSync(typesDir)) {
+        fs.mkdirSync(typesDir, { recursive: true });
+    }
+
+    const content = `/**
+ * Auto-generated type declarations for virtual:postcss-processors
+ * Do not edit manually.
+ */
+declare module 'virtual:postcss-processors' {
+    /**
+     * Process a style string through all registered PostCSS helpers.
+     * Automatically detects which helpers to apply based on the content.
+     */
+    export function processStyle(styleString: string): string;
+}
+`;
+
+    fs.writeFileSync(path.join(typesDir, 'gen-postcss-processors.d.ts'), content, 'utf-8');
+}

--- a/config/postcss-helpers/virtual-module.ts
+++ b/config/postcss-helpers/virtual-module.ts
@@ -1,0 +1,38 @@
+export type Helper = {
+    name: string;
+    process: (value: string) => string;
+};
+
+export function generateVirtualModuleCode(helpers: Helper[], regex: RegExp): string {
+    const processorEntries = helpers
+        .map(({ name, process }) => {
+            return `    '${name}': ${process.toString()}`;
+        })
+        .join(',\n');
+
+    const regexSource = regex.source;
+    const regexFlags = regex.flags;
+
+    return `
+const processors = {
+${processorEntries}
+};
+
+const helperPattern = new RegExp(${JSON.stringify(regexSource)}, ${JSON.stringify(regexFlags)});
+
+export function processStyle(styleString) {
+    if (!helperPattern.test(styleString)) {
+        return styleString;
+    }
+
+    helperPattern.lastIndex = 0;
+    let result = styleString;
+
+    for (const processor of Object.values(processors)) {
+        result = processor(result);
+    }
+
+    return result;
+}
+    `;
+}


### PR DESCRIPTION
> [!WARNING]
> Requires **[locomotivemtl/front-end-helpers#12](https://github.com/locomotivemtl/front-end-helpers/pull/12)** to be merged and published first.
> The integration calls `plugin.helpers` and `plugin.regex`, which are not yet exposed by `@locomotivemtl/postcss-helpers-functions`.

---

## Summary

Adds an Astro integration (`postCssProcessorsHelpersIntegration`) that registers `@locomotivemtl/postcss-helpers-functions` as a PostCSS plugin and simultaneously exposes its helpers at runtime via a Vite virtual module (`virtual:postcss-processors`). The virtual module lets components apply the same CSS transformations in JS without duplicating logic. TypeScript declarations for the module are auto-generated on every dev/build startup.

**Changed files:**
- `astro.config.ts` *(modified)*
- `config/postcss-helpers/postCssProcessorsHelpersIntegration.ts` *(new)*
- `config/postcss-helpers/virtual-module.ts` *(new)*
- `config/postcss-helpers/postcssHelpersToType.ts` *(new)*
- `config/postcss-helpers/README.md` *(new)*

---

## Why

`@locomotivemtl/postcss-helpers-functions` was already wired into the Vite PostCSS pipeline but only processed CSS at compile time. Components that compute inline styles in JS had no way to apply the same transformations — leading to either duplicated logic or raw, unprocessed values at runtime.

- Virtual module shares the package's helper functions with JS/TS without re-implementing them
- Type generation keeps `virtual:postcss-processors` typed without manual maintenance
- Single Astro integration registers both concerns (PostCSS plugin + virtual module) in one call

---

## How It Works

```
astro.config.ts
└── postCssProcessorsHelpersIntegration()          Astro integration
    ├── postcssHelpersFunctions()                  PostCSS plugin (CSS compile-time)
    │   ├── plugin.helpers  →  Helper[]            exposed by package (pending PR #12)
    │   └── plugin.regex    →  RegExp
    ├── generateVirtualModuleCode(helpers, regex)  builds JS module string
    │   └── virtual-module.ts
    └── Vite plugin: virtual:postcss-processors    runtime JS access
        └── export function processStyle(s)
```

On `astro:config:setup`, the integration:
1. Calls `postcssHelpersFunctions()` once, reusing the same instance for both PostCSS and the virtual module
2. Registers the PostCSS plugin via `updateConfig`
3. Registers a Vite plugin that resolves `virtual:postcss-processors` and returns generated JS on load
4. Calls `postcssHelpersToType()` to write `types/gen-postcss-processors.d.ts`

### `virtual-module.ts`

Serializes the helpers array into a self-contained JS module string. Each helper's `process` function is inlined via `.toString()`, so the virtual module has no runtime imports.

### `postcssHelpersToType.ts`

Writes a `declare module 'virtual:postcss-processors'` block to `types/gen-postcss-processors.d.ts`. Runs on every startup so the type is always present before TypeScript checks.

---

## Code Changes

### `astro.config.ts`

```diff
+ import postCssProcessorsHelpersIntegration from './config/postcss-helpers/postCssProcessorsHelpersIntegration';

  integrations: [
+     postCssProcessorsHelpersIntegration(),
      icon({ iconDir: './src/assets/svgs' })
  ]
```

---

## Usage

```ts
import { processStyle } from 'virtual:postcss-processors';

// Apply CSS helpers in JS (e.g. for inline styles or canvas rendering)
const value = processStyle('dvh(100)');
// → 'calc(100 * var(--dvh, 1dvh))'
```

Available helpers mirror `@locomotivemtl/postcss-helpers-functions`: `dvh`, `svh`, `lvh`, `vw`, `rem`, `grid-space`, `responsive-value`.

---

## Testing

- [ ] [locomotivemtl/front-end-helpers#12](https://github.com/locomotivemtl/front-end-helpers/pull/12) merged and `@locomotivemtl/postcss-helpers-functions` updated in `package.json`
- [ ] `npm run dev` starts without errors; `types/gen-postcss-processors.d.ts` is created
- [ ] `import { processStyle } from 'virtual:postcss-processors'` resolves without TS errors
- [ ] `processStyle('dvh(100)')` returns `calc(100 * var(--dvh, 1dvh))`
- [ ] CSS helpers (e.g. `width: dvh(100)`) still compile correctly in `.css` / `.astro` files
