### PR TITLE
feat(utils): expand maths utility library

### DIFF
--- a/src/scripts/utils/maths.ts
+++ b/src/scripts/utils/maths.ts
@@ -1,18 +1,93 @@
-const mapRange = (min: number, max: number, nmin: number, nmax: number, value: number) => {
-    return ((value - min) / (max - min)) * (nmax - nmin) + nmin;
-};
-
-const clamp = (min: number, max: number, value: number) => {
+export const clamp = (value: number, min: number = 0, max: number = 1) => {
     return Math.max(min, Math.min(value, max));
 };
 
-const normalize = (min: number, max: number, value: number) => {
-    return clamp(0, 1, (value - min) / (max - min));
+export const map = (value: number, min: number, max: number, nmin: number, nmax: number) => {
+    return ((value - min) / (max - min)) * (nmax - nmin) + nmin;
 };
 
-const roundToDecimals = (value: number, decimals: number): number => {
+export function mapClamp(
+    value: number,
+    start1: number,
+    stop1: number,
+    start2: number,
+    stop2: number
+): number {
+    const v = start2 + (stop2 - start2) * ((value - start1) / (stop1 - start1));
+    let min = start2;
+    let max = stop2;
+    if (start2 > stop2) {
+        min = stop2;
+        max = start2;
+    }
+    return Math.max(min, Math.min(max, v));
+}
+
+export const normalize = (value: number, min: number, max: number) => {
+    return clamp((value - min) / (max - min), 0, 1);
+};
+
+export const roundToDecimals = (value: number, decimals: number): number => {
     const factor = Math.pow(10, decimals);
     return Math.round((value + Number.EPSILON) * factor) / factor;
 };
 
-export { mapRange, clamp, normalize, roundToDecimals };
+export function lerp(start: number, end: number, t: number): number {
+    return start * (1 - t) + end * t;
+}
+export function lerpPrecise(start: number, end: number, t: number, limit: number = 0.001): number {
+    const v = start * (1 - t) + end * t;
+    return Math.abs(end - v) < limit ? end : v;
+}
+export function damp(a: number, b: number, smoothing: number, dt: number): number {
+    return lerp(a, b, 1 - Math.exp(-smoothing * 0.05 * Math.max(dt, 0)));
+}
+export function dampPrecise(
+    a: number,
+    b: number,
+    smoothing: number,
+    dt: number,
+    limit: number = 0.001
+): number {
+    return lerpPrecise(a, b, 1 - Math.exp(-smoothing * 0.05 * Math.max(dt, 0)), limit);
+}
+
+/**
+ * Mathematical modulo operation that always returns a positive result.
+ * Unlike JavaScript's % operator, this handles negative dividends correctly.
+ * @example mod(-1, 3) = 2 (whereas -1 % 3 = -1)
+ */
+export const mod = (dividend: number, divisor: number): number => {
+    return ((dividend % divisor) + divisor) % divisor;
+};
+
+export const smoothstep = (x: number, min: number, max: number): number => {
+    const t = clamp((x - min) / (max - min), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+};
+
+export function symmetricMod(value: number, base: number): number {
+    let m = value % base;
+    if (Math.abs(m) > base / 2) {
+        m = m > 0 ? m - base : m + base;
+    }
+    return m;
+}
+
+export function yoyo(value: number): number {
+    return 1 - Math.abs(2 * value - 1);
+}
+
+export function average(values: number[]) {
+    let val = 0;
+    const len = values.length;
+    for (let i = 0; i < len; i++) val += values[i];
+    return val / len;
+}
+
+export function median(values: number[] = []) {
+    const numbers = values.slice(0).sort((a, b) => a - b);
+    const middle = Math.floor(numbers.length / 2);
+    const isEven = numbers.length % 2 === 0;
+    return isEven ? (numbers[middle] + numbers[middle - 1]) / 2 : numbers[middle];
+}


### PR DESCRIPTION
## Summary

- Add `lerp`, `lerpPrecise`, `damp`, `dampPrecise` for frame-rate-independent smooth interpolation
- Add `mod` (always-positive modulo), `smoothstep`, `symmetricMod`, `yoyo`
- Add `average` and `median` for array statistics
- Fix argument order: `clamp(value, min, max)` and `normalize(value, min, max)` — **breaking change**
- Rename `mapRange` → `map` — **breaking change**
- Add `mapClamp` for clamped range mapping

## Why

The previous utility was minimal and inconsistent with common conventions (arg order differed from most math libs). The new functions cover the full range of easing, interpolation, and numerical helpers needed across animation-heavy pages.