### PR TITLE
feat(utils/stores): add deep object utils and storage system

### DIFF
--- a/src/scripts/stores/localStorage.ts
+++ b/src/scripts/stores/localStorage.ts
@@ -1,7 +1,4 @@
-/* import { persistentAtom } from "@nanostores/persistent";
+import { useLocalStorage } from '@scripts/utils/storage/useStorage.ts';
 
-export const $locomotiveLocalStorage = persistentAtom<any[]>("locomotive", [], {
-    encode: JSON.stringify,
-    decode: JSON.parse,
-});
- */
+const PROJECT_NAME = (typeof __PROJECT_NAME__ !== 'undefined' && __PROJECT_NAME__) || 'finalfinal';
+export const $storage = useLocalStorage(PROJECT_NAME);

--- a/src/scripts/stores/localStorage.ts
+++ b/src/scripts/stores/localStorage.ts
@@ -1,4 +1,6 @@
 import { useLocalStorage } from '@scripts/utils/storage/useStorage.ts';
 
+// @ts-ignore
+// eslint-ignore-next-line
 const PROJECT_NAME = (typeof __PROJECT_NAME__ !== 'undefined' && __PROJECT_NAME__) || 'finalfinal';
 export const $storage = useLocalStorage(PROJECT_NAME);

--- a/src/scripts/utils/object.ts
+++ b/src/scripts/utils/object.ts
@@ -1,0 +1,121 @@
+/**
+ * Deletes a nested property from an object using a dot-separated key path.
+ *
+ * @param obj - The object from which to delete the property.
+ * @param key - The dot-separated key path (ex: "a.b.c") or a single key.
+ * @returns `true` if the property was found and deleted, `false` otherwise.
+ *
+ * @example
+ * Deleting a nested property
+ * * const obj = { a: { b: { c: 42 } } };
+ * * ddv(obj, 'a.b.c'); // returns true
+ * obj is now { a: { b: {} } }
+ *
+ * @example
+ * Attempting to delete a non-existent property
+ * & const obj = { a: { b: {} } };
+ * ddv(obj, 'a.b.c'); // returns false
+ * obj remains { a: { b: {} } }
+ */
+export function ddv(obj: Record<string, any>, key: string): boolean {
+    const keys = key.split ? key.split('.') : key;
+    const l = keys.length;
+    for (let i = 0; i < l - 1; i++) {
+        const k = keys[i];
+        if (typeof obj[k] !== 'object' || obj[k] === null) {
+            return false;
+        }
+        obj = obj[k];
+    }
+
+    const lastKey = keys[l - 1];
+    if (obj && lastKey in obj) {
+        delete obj[lastKey];
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Deeply retrieves the value at a given path from an object.
+ *
+ * The path is specified as a dot-separated string (ex: "a.b.c").
+ * If the resolved value is `undefined`, the provided default value is returned.
+ *
+ * @param obj - The object to query.
+ * @param key - The dot-separated path string or array of keys.
+ * @param def - The default value to return if the resolved value is `undefined`. Defaults to `null`.
+ * @param p - Internal parameter for recursion (should not be set manually).
+ * @param undef - Internal parameter representing `undefined` (should not be set manually).
+ * @returns The value at the specified path, or the default value if not found.
+ *
+ * @example
+ * Basic usage
+ * const obj = { a: { b: { c: 42 } } };
+ * dlv(obj, 'a.b.c'); // returns 42
+ *
+ * @example
+ * Using a default value
+ * const obj = { a: { b: {} } };
+ * dlv(obj, 'a.b.c', 'not found'); // returns 'not found'
+ *
+ * @example
+ * Accessing a top-level property
+ * const obj = { foo: 'bar' };
+ * dlv(obj, 'foo'); // returns 'bar'
+ */
+// https://github.com/developit/dlv?tab=readme-ov-file
+export function dlv(
+    obj: Record<string, any>,
+    key: string,
+    def: any = null,
+    p = 0,
+    undef: any = undefined
+) {
+    const keys = key.split ? key.split('.') : key;
+    for (p = 0; p < keys.length; p++) {
+        obj = obj ? obj[keys[p]] : undef;
+    }
+    return obj === undef ? def : obj;
+}
+
+/**
+ * Sets or deletes a value in a nested object using a dot-separated key path.
+ *
+ * @param obj - The target object to modify.
+ * @param key - The dot-separated key path (ex: "a.b.c") or a single key.
+ * @param value - The value to set at the specified key path. If `undefined`, the property is deleted.
+ * @returns The modified object.
+ *
+ * @example
+ * Setting a value
+ * * const obj = {};
+ * * dsv(obj, 'a.b.c', 42);
+ * obj is now { a: { b: { c: 42 } } }
+ *
+ * @example
+ * Deleting a value
+ * * dsv(obj, 'a.b.c', undefined);
+ * obj is now { a: { b: {} } }
+ */
+export function dsv(obj: Record<string, any>, key: string, value: any) {
+    if (value === undefined) {
+        ddv(obj, key);
+        return obj;
+    }
+
+    const keys = key.split ? key.split('.') : key;
+    const l = keys.length;
+    for (let i = 0; i < l - 1; i++) {
+        const k = keys[i];
+        if (typeof obj[k] !== 'object' || obj[k] === null) {
+            obj[k] = {};
+        }
+        obj = obj[k];
+    }
+
+    obj[keys[l - 1]] = value;
+
+    return obj;
+}

--- a/src/scripts/utils/storage/index.ts
+++ b/src/scripts/utils/storage/index.ts
@@ -1,0 +1,2 @@
+export * from './useStorage.ts';
+export * from './useStorageState.ts';

--- a/src/scripts/utils/storage/useStorage.ts
+++ b/src/scripts/utils/storage/useStorage.ts
@@ -16,6 +16,8 @@ export const hash = (str: string): string => {
 const IS_PROD = (typeof __IS_PROD__ !== 'undefined' && __IS_PROD__) || false;
 // @ts-ignore
 const TIMESTAMP = (typeof __TIMESTAMP__ !== 'undefined' && __TIMESTAMP__) || '';
+// @ts-ignore
+const DEBUG = !!(typeof __DEBUG__ !== 'undefined' && __DEBUG__);
 
 const list = new Map();
 const p = JSON.parse;
@@ -126,7 +128,7 @@ function createStorage(id: string, storage = localStorage, encode = s, decode = 
                 ddv(datas, childId);
                 _storage.setItem(_id, encode(datas));
             } catch (e) {
-                if (typeof __DEBUG__ !== 'undefined' && __DEBUG__) {
+                if (typeof DEBUG !== 'undefined' && DEBUG) {
                     console.error(e);
                 }
             }

--- a/src/scripts/utils/storage/useStorage.ts
+++ b/src/scripts/utils/storage/useStorage.ts
@@ -13,6 +13,7 @@ export const hash = (str: string): string => {
     return hash.toString(16);
 };
 
+// @ts-ignore
 const IS_PROD = (typeof __IS_PROD__ !== 'undefined' && __IS_PROD__) || false;
 // @ts-ignore
 const TIMESTAMP = (typeof __TIMESTAMP__ !== 'undefined' && __TIMESTAMP__) || '';

--- a/src/scripts/utils/storage/useStorage.ts
+++ b/src/scripts/utils/storage/useStorage.ts
@@ -1,0 +1,235 @@
+import { ddv, dlv, dsv } from '@scripts/utils/object.ts';
+import { hash } from '@scripts/utils/string.ts';
+import { atom, type WritableAtom } from 'nanostores';
+
+const IS_PROD = (typeof __IS_PROD__ !== 'undefined' && __IS_PROD__) || false;
+// @ts-ignore
+const TIMESTAMP = (typeof __TIMESTAMP__ !== 'undefined' && __TIMESTAMP__) || '';
+
+const list = new Map();
+const p = JSON.parse;
+const s = JSON.stringify;
+
+const isAtom = (v: any): v is WritableAtom<any> => {
+    return v && typeof v.subscribe === 'function' && typeof v.set === 'function';
+};
+
+export interface StorageObject {
+    id: string;
+    storage: Storage;
+    datas: Record<string, any>;
+    sync: (key: string, state: any, resetStorage?: boolean) => WritableAtom;
+    get: (key: string, def?: any) => any;
+    set: (key: string, value: any) => void;
+    remove: (key: string) => void;
+    clear: () => void;
+    folder: (subKey: string) => StorageObject;
+}
+
+function createStorage(id: string, storage = localStorage, encode = s, decode = p): StorageObject {
+    const _storage = storage;
+    const _id = id;
+
+    // Map to keep track of nanostores subscription disposers for each key.
+    // This allows us to unsubscribe when a key is re‑synced or when the storage
+    // is disposed, preventing dangling listeners that could cause memory leaks.
+    const _unsubMap = new Map<string, () => void>();
+
+    // ---------------------------------------------------------------------
+    // Simple write‑queue to avoid concurrent writes to the underlying storage.
+    // All mutating operations (set, remove, clear) are enqueued and executed
+    // sequentially using requestIdleCallback. This prevents race conditions when
+    // multiple parts of the app (or multiple tabs) try to write at the same time.
+    // ---------------------------------------------------------------------
+    const _writeQueue: Array<() => void> = [];
+    let _processingQueue = false;
+
+    const enqueueWrite = (op: () => void) => {
+        _writeQueue.push(op);
+        if (!_processingQueue) {
+            _processingQueue = true;
+            // Use requestIdleCallback if available, otherwise fallback to setTimeout.
+            const schedule =
+                typeof requestIdleCallback === 'function'
+                    ? requestIdleCallback
+                    : (cb: any) => setTimeout(cb, 0);
+            schedule(processWriteQueue);
+        }
+    };
+
+    const processWriteQueue = (deadline?: any) => {
+        while (_writeQueue.length && (!deadline || deadline.timeRemaining() > 0)) {
+            const op = _writeQueue.shift();
+            if (op) op();
+        }
+        if (_writeQueue.length) {
+            const schedule =
+                typeof requestIdleCallback === 'function'
+                    ? requestIdleCallback
+                    : (cb: any) => setTimeout(cb, 0);
+            schedule(processWriteQueue);
+        } else {
+            _processingQueue = false;
+        }
+    };
+
+    // Initialise storage if missing
+    if (_storage.getItem(_id) === null) {
+        _storage.setItem(_id, encode({}));
+    }
+
+    const datas = decode(_storage.getItem(_id) || '{}') as Record<string, any>;
+
+    // ----- Helper functions -----
+    function sync(key: string, state: WritableAtom, resetStorage = IS_PROD) {
+        if (!isAtom(state)) state = atom(state);
+
+        if (resetStorage) set(key, state.get());
+
+        const data = get(key, state.get());
+        state.set(data);
+
+        // If we already have a subscription for this key, unsubscribe first.
+        const previousUnsub = _unsubMap.get(key);
+        if (previousUnsub) previousUnsub();
+
+        const unsub = state.subscribe((value) => set(key, value));
+        _unsubMap.set(key, unsub);
+        return state;
+    }
+
+    function set(childId: string, data: any) {
+        enqueueWrite(() => {
+            dsv(datas, childId, data);
+            _storage.setItem(_id, encode(datas));
+        });
+    }
+
+    function get(childId: string, def: any = null) {
+        return dlv(datas, childId, def);
+    }
+
+    function remove(childId: string) {
+        enqueueWrite(() => {
+            try {
+                ddv(datas, childId);
+                _storage.setItem(_id, encode(datas));
+            } catch (e) {
+                if (typeof __DEBUG__ !== 'undefined' && __DEBUG__) {
+                    console.error(e);
+                }
+            }
+        });
+    }
+
+    function clear() {
+        enqueueWrite(() => {
+            // Remove the stored item.
+            _storage.removeItem(_id);
+        });
+        // Unsubscribe all listeners to avoid leaks.
+        _unsubMap.forEach((unsub) => unsub());
+        _unsubMap.clear();
+    }
+
+    // Return all the methods of this storage with the subKey as a prefix
+    function folder(subKey: string) {
+        subKey = subKey.toLowerCase();
+
+        // Ensure the subKey exists
+        if (!get(subKey)) {
+            set(subKey, {});
+        }
+
+        return {
+            get id() {
+                return `${_id}.${subKey}`;
+            },
+            get subId() {
+                return subKey;
+            },
+            get storage() {
+                return _storage;
+            },
+            get datas() {
+                return dlv(datas, subKey, {});
+            },
+            sync: (key: string, state: WritableAtom, resetStorage = IS_PROD) =>
+                sync(`${subKey}.${key}`, state, resetStorage),
+            get: (key: string, def: any) => get(`${subKey}.${key}`, def),
+            set: (key: string, value: any) => set(`${subKey}.${key}`, value),
+            remove: (key: string) => remove(`${subKey}.${key}`),
+            // Reset the sub‑folder to an empty object and clean up any listeners for that sub‑key
+            clear: () => {
+                // Unsubscribe any listeners that were created for keys belonging to this sub‑folder.
+                const prefix = `${subKey}.`;
+                for (const key of _unsubMap.keys()) {
+                    if (key === subKey || key.startsWith(prefix)) {
+                        const unsub = _unsubMap.get(key);
+                        if (unsub) unsub();
+                        _unsubMap.delete(key);
+                    }
+                }
+                // Reset the stored object for the sub‑folder.
+                set(subKey, {});
+            },
+            folder: (key: string) => folder(`${subKey}.${key}`)
+        };
+    }
+
+    // ----- Public storage object -----
+    return {
+        get id() {
+            return _id;
+        },
+        get storage() {
+            return _storage;
+        },
+        get datas() {
+            return datas;
+        },
+        sync,
+        get,
+        set,
+        remove,
+        clear,
+        folder
+    };
+}
+
+// Create a storage object
+export function useStorage(
+    _id = 'dummy',
+    _storage = localStorage,
+    { encode = s, decode = p } = {}
+): StorageObject {
+    // return the dummy storage if no id
+
+    // normalize id
+    _id = _id.toLowerCase();
+
+    // Avoid leaking storage objects in production
+    if (IS_PROD) _id += hash(_id + TIMESTAMP);
+
+    // return storage if it exists
+    if (list.has(_id)) {
+        if (list.get(_id).storage === _storage) {
+            return list.get(_id);
+        }
+    }
+
+    // create storage if it doesn't exist
+    const id = `__storage.${_id}`;
+    const storage = createStorage(id, _storage, encode, decode);
+    list.set(_id, storage);
+
+    return storage;
+}
+
+export function useLocalStorage(id: string, { encode = s, decode = p } = {}): StorageObject {
+    return useStorage(id, localStorage, { encode, decode });
+}
+
+export function useSessionStorage(id: string, { encode = s, decode = p } = {}): StorageObject {
+    return useStorage(id, sessionStorage, { encode, decode });
+}

--- a/src/scripts/utils/storage/useStorage.ts
+++ b/src/scripts/utils/storage/useStorage.ts
@@ -1,6 +1,17 @@
 import { ddv, dlv, dsv } from '@scripts/utils/object.ts';
-import { hash } from '@scripts/utils/string.ts';
+// import { hash } from '@scripts/utils/string.ts';
 import { atom, type WritableAtom } from 'nanostores';
+
+/* Hotfix for the PR */
+/* Will be imported from '@scripts/utils/string.ts' */
+export const hash = (str: string): string => {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash |= 0; // Convert to 32bit integer
+    }
+    return hash.toString(16);
+};
 
 const IS_PROD = (typeof __IS_PROD__ !== 'undefined' && __IS_PROD__) || false;
 // @ts-ignore

--- a/src/scripts/utils/storage/useStorageState.ts
+++ b/src/scripts/utils/storage/useStorageState.ts
@@ -1,0 +1,28 @@
+import { atom, type WritableAtom } from 'nanostores';
+
+const p = JSON.parse;
+const s = JSON.stringify;
+
+const isAtom = (v: any): v is WritableAtom<any> => {
+    return v && typeof v.subscribe === 'function' && typeof v.set === 'function';
+};
+
+// Create an writable signal that syncs with localStorage
+// independently of the project storage (cf. useStorage)
+export function useStorageState(
+    id: string,
+    state: WritableAtom,
+    storage = localStorage,
+    { encode = s, decode = p } = {}
+) {
+    id = `__storage_state:${id}`;
+
+    if (!isAtom(state)) state = atom(state);
+
+    if (storage.getItem(id) === null) storage.setItem(id, encode(state.value));
+
+    state.set(decode(storage.getItem(id) || 'null'));
+    state.subscribe((value) => storage.setItem(id, encode(value)));
+
+    return state;
+}


### PR DESCRIPTION
## Summary

**`utils/object.ts`** — dot-notation deep access helpers:
- `dlv(obj, 'a.b.c', default)` — safe deep get
- `dsv(obj, 'a.b.c', value)` — deep set (creates intermediate objects)
- `ddv(obj, 'a.b.c')` — deep delete, returns `true` if found

**`utils/storage/`** — project-scoped localStorage/sessionStorage:
- `useStorage(id, storage)` — singleton per id+storage, returns a `StorageObject`
- `useLocalStorage(id)` / `useSessionStorage(id)` — convenience wrappers
- `.sync(key, atom)` — two-way bind a nanostores atom to a storage key
- `.folder(subKey)` — nested namespacing within the same storage entry
- `.set/.get/.remove/.clear` — direct read/write
- `useStorageState(id, atom)` — simple single-atom localStorage sync independent of project storage

**`stores/localStorage.ts`** — replace `@nanostores/persistent` with `useLocalStorage`. Project name driven by `__PROJECT_NAME__` build variable.

## Why

`@nanostores/persistent` is too simplistic for multi-key scoped storage with folder-level isolation, write queuing, and production key hashing. The new system also centralises the serialization/deserialization logic and prevents race conditions via an idle-callback write queue.

## How It Works

All writes go through `enqueueWrite` which schedules work with `requestIdleCallback` (falls back to `setTimeout`). In production the storage key is suffixed with `hash(id + __TIMESTAMP__)` so stale data from previous builds is automatically invalidated.

## Dependencies

- `utils/object` — `dlv`, `dsv`, `ddv` (dot-notation deep access)
- `utils/string` — `hash` (prod key fingerprinting)