### PR TITLE
feat(utils): add async utilities, replace ts-debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
                 "nanostores": "^1.0.1",
                 "swup": "^4.8.1",
                 "tailwindcss": "^4.2.1",
-                "ts-debounce": "^4.0.0",
                 "typescript": "^5.9.3"
             },
             "devDependencies": {
@@ -2201,6 +2200,70 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.2.1",
@@ -7076,11 +7139,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
-        },
-        "node_modules/ts-debounce": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
-            "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg=="
         },
         "node_modules/tsconfck": {
             "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         "nanostores": "^1.0.1",
         "swup": "^4.8.1",
         "tailwindcss": "^4.2.1",
-        "ts-debounce": "^4.0.0",
         "typescript": "^5.9.3"
     },
     "devDependencies": {

--- a/src/scripts/stores/screen.ts
+++ b/src/scripts/stores/screen.ts
@@ -1,5 +1,5 @@
 import { map } from 'nanostores';
-import { debounce } from 'ts-debounce';
+import { debounce } from '@scripts/utils/async';
 
 export type ScreenValues = {
     width: number;

--- a/src/scripts/utils/async/debounce.ts
+++ b/src/scripts/utils/async/debounce.ts
@@ -1,0 +1,37 @@
+export type Debounce<T extends (...args: any[]) => void> = ((...args: Parameters<T>) => void) & {
+    cancel: () => void;
+};
+export type Throttle<T extends (...args: any[]) => void> = (...args: Parameters<T>) => void;
+
+export const debounce = <T extends (...args: any[]) => void>(fn: T, ms: number): Debounce<T> => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const debounced = (...args: Parameters<T>) => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), ms);
+    };
+
+    debounced.cancel = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    return debounced;
+};
+
+export const throttle = <T extends (...args: any[]) => void>(fn: T, ms: number): Throttle<T> => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const throttled = (...args: Parameters<T>) => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+            if (timer) clearTimeout(timer);
+            timer = null;
+            fn(...args);
+        }, ms);
+    };
+
+    return throttled;
+};

--- a/src/scripts/utils/async/deferredPromise.ts
+++ b/src/scripts/utils/async/deferredPromise.ts
@@ -1,0 +1,21 @@
+// Extraction of resolve / reject are made outside of the promise
+// to avoid recreating a function each time the promise is created.
+export interface DeferredPromise<T = PromiseLike<unknown>> {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+}
+export type DeferredPromiseResolve<T = unknown> = (value: T | PromiseLike<T>) => void;
+export type DeferredPromiseReject = (reason?: any) => void;
+
+export function deferredPromise<T = unknown>(): DeferredPromise<T> {
+    let resolve: (value: T | PromiseLike<T>) => void;
+    let reject: (reason?: any) => void;
+
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, resolve: resolve!, reject: reject! };
+}

--- a/src/scripts/utils/async/index.ts
+++ b/src/scripts/utils/async/index.ts
@@ -1,0 +1,3 @@
+export * from './wait.ts';
+export * from './deferredPromise.ts';
+export * from './debounce.ts';

--- a/src/scripts/utils/async/wait.ts
+++ b/src/scripts/utils/async/wait.ts
@@ -1,0 +1,137 @@
+/**
+ * Waits for a specified number of milliseconds using setTimeout.
+ * @param ms - Number of milliseconds to wait
+ * @returns Promise that resolves after the specified duration
+ * @example
+ * ```ts
+ * await wait(1000); // Wait 1 second
+ * ```
+ */
+export const wait = (ms: number): Promise<void> => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Waits for the next animation frame using requestAnimationFrame.
+ * Useful for waiting until the browser is ready to render the next frame.
+ * @returns Promise that resolves with null on the next animation frame
+ * @example
+ * ```ts
+ * await nextFrame(); // Wait for next frame before continuing
+ * ```
+ */
+export const nextFrame = (): Promise<null> =>
+    new Promise<null>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null))));
+
+/**
+ * Waits for one or more event loop ticks using setTimeout(0).
+ * Useful for deferring execution until after the current call stack clears.
+ * @param times - Number of ticks to wait (default: 0, which means 1 tick)
+ * @returns Promise that resolves after the specified number of ticks
+ * @example
+ * ```ts
+ * await nextTick(); // Wait 1 tick
+ * await nextTick(3); // Wait 3 ticks
+ * ```
+ */
+export const nextTick = (times = 0): Promise<void> => {
+    if (times > 0) {
+        return new Promise<void>((r) => setTimeout(() => nextTick(times - 1).then(r), 0));
+    }
+    return new Promise<void>((r) => setTimeout(r, 0));
+};
+
+export const nextMicrotask = (): Promise<void> => {
+    return new Promise<void>((r) => queueMicrotask(r));
+};
+
+/**
+ * Creates an interval that runs a callback at a specified interval using requestAnimationFrame.
+ * More accurate than setInterval for frame-based animations as it syncs with the browser's refresh rate.
+ * The callback receives a cancel function that can be used to stop the interval.
+ *
+ * **Important**: Unlike `setInterval`, the callback will not fire while the user is away from the page
+ * (tab is inactive/backgrounded). Once the user returns to the page, the callback will resume and fire
+ * as expected. This behavior matches the browser's requestAnimationFrame API.
+ * @param cb - Callback function that receives a cancel function as its parameter
+ * @param ms - Interval duration in milliseconds
+ * @returns Object with a cancel method to stop the interval
+ * @example
+ * ```ts
+ * const interval = rafSetInterval((cancel) => {
+ *   console.log('Running every 100ms');
+ *   if (someCondition) cancel(); // Stop the interval
+ * }, 100);
+ *
+ * // Later, stop it manually
+ * interval.cancel();
+ * ```
+ */
+export const rafSetInterval = (
+    cb: (cancel: () => void) => void,
+    ms: number
+): { cancel: () => void } => {
+    let rafid: number | undefined;
+    let last: number = 0;
+    let isCanceled = false;
+
+    const cancel = () => {
+        isCanceled = true;
+    };
+
+    const loop = () => {
+        const now = performance.now();
+        const elapsed = now - last;
+
+        if (elapsed >= ms) {
+            cb(cancel);
+            last = now;
+        }
+
+        if (isCanceled) return rafid && cancelAnimationFrame(rafid);
+
+        rafid = requestAnimationFrame(loop);
+    };
+
+    rafid = requestAnimationFrame(loop);
+
+    return { cancel };
+};
+
+/**
+ * Waits for a specified duration using requestAnimationFrame instead of setTimeout.
+ * More accurate for frame-based timing as it syncs with the browser's refresh rate.
+ * Automatically cleans up the animation frame request if the promise is rejected or canceled.
+ *
+ * **Important**: Unlike `setTimeout`, the promise will not resolve while the user is away from the page
+ * (tab is inactive/backgrounded). Once the user returns to the page, the promise will resolve as expected.
+ * This behavior matches the browser's requestAnimationFrame API.
+ * @param ms - Number of milliseconds to wait
+ * @returns Promise that resolves after the specified duration
+ * @example
+ * ```ts
+ * await rafWait(1000); // Wait 1 second using RAF
+ * ```
+ */
+export const rafWait = async (ms: number): Promise<void> => {
+    let rafid: number | undefined;
+
+    try {
+        return await new Promise<void>((resolve) => {
+            let start: number | null = null;
+
+            const loop = (t_1: number) => {
+                if (start === null) start = t_1;
+                const elapsed = t_1 - start;
+
+                if (elapsed >= ms) {
+                    resolve();
+                } else {
+                    rafid = requestAnimationFrame(loop);
+                }
+            };
+
+            rafid = requestAnimationFrame(loop);
+        });
+    } finally {
+        if (rafid !== undefined) cancelAnimationFrame(rafid);
+    }
+};


### PR DESCRIPTION
## Summary

**`utils/async/debounce.ts`**
- `debounce(fn, ms)` — trailing-edge debounce with `.cancel()` method
- `throttle(fn, ms)` — leading-edge throttle

**`utils/async/wait.ts`**
- `wait(ms)` — `setTimeout`-based delay
- `nextFrame()` — double-rAF (guarantees paint has happened)
- `nextTick(n)` — `n` event-loop ticks via `setTimeout(0)`
- `nextMicrotask()` — `queueMicrotask` wrapper
- `rafWait(ms)` — rAF-based delay that pauses when the tab is hidden
- `rafSetInterval(cb, ms)` — rAF-synced repeating interval with cancel

**`utils/async/deferredPromise.ts`**
- `deferredPromise()` — externalized `resolve`/`reject` to avoid closure re-creation

**`package.json`** — removes `ts-debounce` (replaced by the local `debounce` impl above)

## Why

`ts-debounce` was the only external dependency used for a trivial utility. Inlining removes the dep and gives us `throttle`, `cancel`, and the full async timing toolkit without adding weight.

## Dependencies

None — this PR removes a dependency, not adds one.

> **Note:** Dependent PRs (`utils/screen`, `stores/screen`) use `@scripts/utils/async/debounce` and must be merged after this one.