### PR TITLE
feat(utils/stores): add screen observer utilities

### DIFF
--- a/src/scripts/stores/screen.ts
+++ b/src/scripts/stores/screen.ts
@@ -1,37 +1,41 @@
 import { map } from 'nanostores';
-import { debounce } from 'ts-debounce';
+import { useScreen } from '@scripts/utils/screen/useScreen.ts';
 
 export type ScreenValues = {
     width: number;
     height: number;
-};
-
-export type ScreenDebounceValues = {
-    width: number;
-    height: number;
+    dpr: number;
+    ratio: number;
 };
 
 export const $screen = map<ScreenValues>({
     width: window.innerWidth,
-    height: window.innerHeight
+    height: window.innerHeight,
+    dpr: window.devicePixelRatio || 1,
+    ratio: window.innerWidth / window.innerHeight
 });
 
-export const $screenDebounce = map<ScreenDebounceValues>({
-    width: window.innerWidth,
-    height: window.innerHeight
+export const $screenDebounce = map<ScreenValues>({
+    ...$screen.get()
 });
 
-window.addEventListener('resize', () => {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-
-    $screen.set({ width, height });
+// Use useScreen hook to watch for screen changes
+useScreen({
+    onUpdate: (api) => {
+        $screen.set({
+            width: api.width,
+            height: api.height,
+            dpr: api.dpr,
+            ratio: api.ratio
+        });
+    },
+    onDebouncedUpdate: (api) => {
+        $screenDebounce.set({
+            width: api.width,
+            height: api.height,
+            dpr: api.dpr,
+            ratio: api.ratio
+        });
+    },
+    debounceTime: 200
 });
-
-const debouncedFunction: any = () => {
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-
-    $screenDebounce.set({ width, height });
-};
-window.addEventListener('resize', debounce(debouncedFunction, 200));

--- a/src/scripts/utils/screen/useDPR.ts
+++ b/src/scripts/utils/screen/useDPR.ts
@@ -1,0 +1,46 @@
+export interface UseDPRInstance {
+    value: number;
+    start: () => void;
+    stop: () => void;
+}
+
+export function useDPR(onUpdate: (value: number) => void = () => {}): UseDPRInstance {
+    let pixelRatio = window.devicePixelRatio || 1;
+    let mediaQueryList: MediaQueryList | null = null;
+
+    const api = {
+        get value() {
+            return pixelRatio;
+        },
+        start,
+        stop
+    };
+
+    start();
+
+    function updatePixelRatio() {
+        pixelRatio = window.devicePixelRatio || 1;
+        onUpdate(pixelRatio);
+        setupMediaQuery();
+    }
+
+    function setupMediaQuery() {
+        stop();
+
+        const query = `(resolution: ${pixelRatio}dppx)`;
+        mediaQueryList = window.matchMedia(query);
+        mediaQueryList.addEventListener('change', updatePixelRatio);
+    }
+
+    function start() {
+        setupMediaQuery();
+        updatePixelRatio();
+    }
+
+    function stop() {
+        mediaQueryList?.removeEventListener('change', updatePixelRatio);
+        mediaQueryList = null;
+    }
+
+    return api;
+}

--- a/src/scripts/utils/screen/useResize.ts
+++ b/src/scripts/utils/screen/useResize.ts
@@ -1,0 +1,94 @@
+import { debounce } from '@scripts/utils/async/debounce.ts';
+
+export interface UseResizeInstance {
+    width: number;
+    height: number;
+    ratio: number;
+    start: () => void;
+    stop: () => void;
+    destroy: () => void;
+}
+
+export interface UseResizeOptions {
+    onUpdate?: (api: UseResizeInstance) => void;
+    onDebouncedUpdate?: (api: UseResizeInstance) => void;
+    debounceTime?: number;
+    autoStart?: boolean;
+}
+
+export function useResize($el: HTMLElement, options?: UseResizeOptions): UseResizeInstance {
+    const {
+        onUpdate = () => {},
+        onDebouncedUpdate = () => {},
+        debounceTime = 200,
+        autoStart = true
+    } = options || {};
+
+    let width = $el.clientWidth || 0;
+    let height = $el.clientHeight || 0;
+    let ratio = width / height || 0;
+
+    const resizeObserver = new ResizeObserver(updateSize);
+    const debouncedUpdate = debounce(onDebouncedUpdate, debounceTime);
+
+    const api = {
+        observer: resizeObserver,
+        get width() {
+            return width;
+        },
+        get height() {
+            return height;
+        },
+        get ratio() {
+            return ratio;
+        },
+        start,
+        stop,
+        destroy
+    };
+
+    if (autoStart) start();
+
+    return api;
+
+    function updateSize(entries: ResizeObserverEntry[]) {
+        const entry = entries[0];
+        if (!entry) return;
+
+        const contentBoxSize = entry.contentRect;
+        const newWidth = contentBoxSize.width || $el.clientWidth || 0;
+        const newHeight = contentBoxSize.height || $el.clientHeight || 0;
+        const newRatio = newWidth / newHeight || 0;
+
+        const hasChanged = newWidth !== width || newHeight !== height || newRatio !== ratio;
+
+        if (hasChanged) {
+            width = newWidth;
+            height = newHeight;
+            ratio = newRatio;
+            callCallbacks();
+        }
+    }
+
+    function callCallbacks() {
+        onUpdate(api);
+        debouncedUpdate(api);
+    }
+
+    function start() {
+        // Ensure we don't observe multiple times
+        resizeObserver.unobserve($el);
+        resizeObserver.observe($el);
+        callCallbacks();
+    }
+
+    function stop() {
+        resizeObserver.unobserve($el);
+        debouncedUpdate.cancel();
+    }
+
+    function destroy() {
+        stop();
+        resizeObserver.disconnect();
+    }
+}

--- a/src/scripts/utils/screen/useResize.ts
+++ b/src/scripts/utils/screen/useResize.ts
@@ -1,4 +1,27 @@
-import { debounce } from '@scripts/utils/async/debounce.ts';
+// import { debounce } from '@scripts/utils/async/debounce.ts';
+
+/* Hotfix for the PR */
+/* Will be imported from '@scripts/utils/async/debounce.ts' */
+export type Debounce<T extends (...args: any[]) => void> = ((...args: Parameters<T>) => void) & {
+    cancel: () => void;
+};
+export const debounce = <T extends (...args: any[]) => void>(fn: T, ms: number): Debounce<T> => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const debounced = (...args: Parameters<T>) => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), ms);
+    };
+
+    debounced.cancel = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    return debounced;
+};
 
 export interface UseResizeInstance {
     width: number;

--- a/src/scripts/utils/screen/useScreen.ts
+++ b/src/scripts/utils/screen/useScreen.ts
@@ -1,4 +1,27 @@
-import { debounce } from '@scripts/utils/async/debounce.ts';
+// import { debounce } from '@scripts/utils/async/debounce.ts';
+
+/* Hotfix for the PR */
+/* Will be imported from '@scripts/utils/async/debounce.ts' */
+export type Debounce<T extends (...args: any[]) => void> = ((...args: Parameters<T>) => void) & {
+    cancel: () => void;
+};
+export const debounce = <T extends (...args: any[]) => void>(fn: T, ms: number): Debounce<T> => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const debounced = (...args: Parameters<T>) => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => fn(...args), ms);
+    };
+
+    debounced.cancel = () => {
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+        }
+    };
+
+    return debounced;
+};
 
 export interface UseScreenInstance {
     width: number;

--- a/src/scripts/utils/screen/useScreen.ts
+++ b/src/scripts/utils/screen/useScreen.ts
@@ -1,0 +1,79 @@
+import { debounce } from '@scripts/utils/async/debounce.ts';
+
+export interface UseScreenInstance {
+    width: number;
+    height: number;
+    ratio: number;
+    dpr: number;
+    start: () => void;
+    stop: () => void;
+}
+
+export interface UseScreenOptions {
+    onUpdate?: (api: UseScreenInstance) => void;
+    onDebouncedUpdate?: (api: UseScreenInstance) => void;
+    debounceTime?: number;
+}
+
+export function useScreen(options: UseScreenOptions = {}): UseScreenInstance {
+    const { onUpdate = () => {}, onDebouncedUpdate = () => {}, debounceTime = 200 } = options;
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let ratio = width / height;
+
+    const debouncedUpdate = debounce(onDebouncedUpdate, debounceTime);
+
+    const api = {
+        get width() {
+            return width;
+        },
+        get height() {
+            return height;
+        },
+        get ratio() {
+            return ratio;
+        },
+        get dpr() {
+            return window.devicePixelRatio ?? 1;
+        },
+        start,
+        stop
+    };
+
+    start();
+
+    return api;
+
+    function callCallbacks() {
+        onUpdate(api);
+        debouncedUpdate(api);
+    }
+
+    function updateScreen() {
+        const newWidth = window.innerWidth;
+        const newHeight = window.innerHeight;
+        const newRatio = newWidth / newHeight;
+
+        const hasChanged = newWidth !== width || newHeight !== height || newRatio !== ratio;
+
+        if (hasChanged) {
+            width = newWidth;
+            height = newHeight;
+            ratio = newRatio;
+            callCallbacks();
+        }
+    }
+
+    function start() {
+        window.addEventListener('resize', updateScreen);
+        window.addEventListener('orientationchange', updateScreen);
+        callCallbacks();
+    }
+
+    function stop() {
+        window.removeEventListener('resize', updateScreen);
+        window.removeEventListener('orientationchange', updateScreen);
+        debouncedUpdate.cancel();
+    }
+}


### PR DESCRIPTION
## Summary

**`utils/screen/useScreen`**
- Observes `resize` + `orientationchange` on `window`
- Fires an immediate `onUpdate` callback on every change
- Fires a debounced `onDebouncedUpdate` callback (default 200ms)
- Exposes `{ width, height, ratio, dpr }` (DPR is live via `devicePixelRatio`)
- `start()` / `stop()` lifecycle

**`utils/screen/useResize`**
- `ResizeObserver` wrapper for element-level size tracking
- Same immediate + debounced callback pattern as `useScreen`
- `autoStart` option (default `true`)
- `start()` / `stop()` / `destroy()`

**`utils/screen/useDPR`**
- Watches device pixel ratio via `matchMedia('resolution: Ndppx')`
- Re-registers the listener on every DPR change so it always tracks the current value

**`stores/screen.ts`**
- Replace `import { debounce } from 'ts-debounce'` with `useScreen` hook
- Add `dpr` and `ratio` to `ScreenValues` type
- Unify `$screen` and `$screenDebounce` to the same `ScreenValues` shape

## Why

The old screen store used two raw event listeners and `ts-debounce` directly. The new `useScreen` composable encapsulates that pattern so it can be reused by components that need element-level or window-level resize tracking without coupling to the store.

## Dependencies

- `feat/utils-async` — `useScreen` and `useResize` import `debounce` from `@scripts/utils/async/debounce`