### PR TITLE
feat(utils): add logger and color utilities

### DIFF
--- a/src/scripts/utils/colors/index.ts
+++ b/src/scripts/utils/colors/index.ts
@@ -1,0 +1,2 @@
+export * from './lighten.ts';
+export * from './normalizeColor.ts';

--- a/src/scripts/utils/colors/lighten.ts
+++ b/src/scripts/utils/colors/lighten.ts
@@ -1,0 +1,41 @@
+import { clamp } from '@scripts/utils/maths.ts';
+
+/**
+ * Lightens a color (hex or rgb/rgba) for dark mode
+ * @param color - Color string (hex or rgb/rgba)
+ * @param amount - Lightening factor between 0 and 1 (0 = no change, 1 = white)
+ */
+export const lighten = (color: string, amount: number = 0.3): string => {
+    // Clamp amount between 0 and 1
+    const factor = clamp(amount);
+
+    if (factor === 0) return color; // No change needed
+
+    // Handle rgba/rgb colors
+    if (color.startsWith('rgba') || color.startsWith('rgb')) {
+        const match = color.match(/rgba?\(([^)]+)\)/);
+        if (match) {
+            const values = match[1].split(',').map((v) => v.trim());
+            const r = Math.round(parseInt(values[0]) + (255 - parseInt(values[0])) * factor);
+            const g = Math.round(parseInt(values[1]) + (255 - parseInt(values[1])) * factor);
+            const b = Math.round(parseInt(values[2]) + (255 - parseInt(values[2])) * factor);
+            const alpha = values[3] || '0.2'; // Preserve alpha if present, default to 0.2
+            return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        }
+    }
+
+    // Handle hex colors
+    if (color.startsWith('#')) {
+        const hex = color.slice(1);
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        const lightenedR = Math.round(r + (255 - r) * factor);
+        const lightenedG = Math.round(g + (255 - g) * factor);
+        const lightenedB = Math.round(b + (255 - b) * factor);
+        return `#${lightenedR.toString(16).padStart(2, '0')}${lightenedG.toString(16).padStart(2, '0')}${lightenedB.toString(16).padStart(2, '0')}`;
+    }
+
+    // Fallback: return as is
+    return color;
+};

--- a/src/scripts/utils/colors/normalizeColor.ts
+++ b/src/scripts/utils/colors/normalizeColor.ts
@@ -1,0 +1,32 @@
+/**
+ * Normalizes color input (hex or rgb) to CSS color string
+ */
+export function normalizeColor(color: string): string {
+    // If it's already rgb/rgba, return as is
+    if (color.startsWith('rgb')) {
+        color = color.replace(/rgba?\(([^)]+)\)/, (_, contents) => {
+            // Ensure RGB values are separated by commas
+            const values = contents.split(/[\s,]+/).map((v: string) => v.trim());
+            return `rgb(${values.join(', ')})`;
+        });
+        return color;
+    }
+
+    // If it's hex in 0x format, convert to # format
+    if (color.startsWith('0x')) {
+        return `#${color.slice(2)}`;
+    }
+
+    // If it's hex, ensure it has # prefix
+    if (color.startsWith('#')) {
+        return color;
+    }
+
+    // If it's hex without #, add it
+    if (/^[0-9A-Fa-f]{6}$/.test(color)) {
+        return `#${color}`;
+    }
+
+    // Fallback: return as is (might be a CSS color name)
+    return color;
+}

--- a/src/scripts/utils/log/README.md
+++ b/src/scripts/utils/log/README.md
@@ -1,0 +1,346 @@
+# Logging Utilities
+
+This directory contains two logging utilities for different use cases:
+
+- **`logger.ts`** - Stylized console logger with colored prefixes and backgrounds
+- **`domLogger.ts`** - DOM-based logger that displays logs directly on the page
+
+## Table of Contents
+
+- [Console Logger (`logger.ts`)](#console-logger-loggerts)
+- [DOM Logger (`domLogger.ts`)](#dom-logger-domloggerts)
+- [Color Formats](#color-formats)
+
+---
+
+## Console Logger (`logger.ts`)
+
+A stylized console logger that enhances browser console output with colored prefixes, backgrounds, and custom styling. Perfect for debugging and development.
+
+### Features
+
+- ✅ Colored prefixes with custom identifiers
+- ✅ Background colors with border radius and padding
+- ✅ Predefined colors for different log levels (error, warn, info, debug)
+- ✅ Custom text and background colors
+- ✅ All standard console methods supported
+- ✅ Optimized (prefixes and styles created once)
+
+### Installation
+
+```typescript
+import { createLogger } from '#utils/log/logger.ts';
+```
+
+### Basic Usage
+
+```typescript
+// Create a logger with an ID prefix
+const logger = createLogger({ id: 'LOCO', color: '#312dfb' });
+
+logger.log('Hello world');
+logger.info('Information message');
+logger.warn('Warning message');
+logger.error('Error message');
+logger.debug('Debug message');
+```
+
+**Output:**
+
+```
+LOCO Hello world
+LOCO • info Information message
+LOCO • warn Warning message
+LOCO • error Error message
+LOCO • debug Debug message
+```
+
+### API Reference
+
+#### `createLogger(options?: LoggerOptions): Logger`
+
+Creates a new logger instance with optional configuration.
+
+**Options:**
+
+| Option            | Type         | Default                  | Description                                                                         |
+| ----------------- | ------------ | ------------------------ | ----------------------------------------------------------------------------------- |
+| `id`              | `string`     | `undefined`              | Prefix identifier (e.g., 'LOCO'). If not provided, no prefix is added.              |
+| `color`           | `ColorInput` | `'#312dfb'`              | Custom text color for `log` method (hex or rgb).                                    |
+| `backgroundColor` | `ColorInput` | `color` with 0.2 opacity | Custom background color. If not provided, uses the text color with reduced opacity. |
+
+**Color Formats:**
+
+- Hex: `'#312dfb'` or `'312dfb'`
+- RGB: `'rgb(49, 45, 251)'` or `'rgb(49 45 251)'`
+- RGBA: `'rgba(49, 45, 251, 0.5)'`
+
+### Examples
+
+#### With Custom Colors
+
+```typescript
+const logger = createLogger({
+    id: 'APP',
+    color: '#ff33ee',
+    backgroundColor: '#ff33ee' // Optional: defaults to color with 0.2 opacity
+});
+
+logger.log('Custom colored log');
+```
+
+#### Without Prefix
+
+```typescript
+const logger = createLogger({ color: '#312dfb' });
+logger.log('No prefix, but still colored');
+```
+
+#### Predefined Log Levels
+
+Each log level has predefined colors:
+
+- **Error**: Red (`#ff3333`) with red background
+- **Warn**: Orange (`#ffaa00`) with orange background
+- **Info**: Blue (`#3399ff`) with blue background
+- **Debug**: Gray (`#999999`) with gray background
+- **Log**: Custom color (default: `#312dfb`) with matching background
+
+```typescript
+const logger = createLogger({ id: 'APP' });
+
+logger.error('This is red');
+logger.warn('This is orange');
+logger.info('This is blue');
+logger.debug('This is gray');
+logger.log('This uses your custom color');
+```
+
+#### All Available Methods
+
+```typescript
+const logger = createLogger({ id: 'APP' });
+
+// Basic logging
+logger.log('Message');
+logger.info('Info');
+logger.warn('Warning');
+logger.error('Error');
+logger.debug('Debug');
+
+// Table display
+logger.table({ name: 'John', age: 30 });
+
+// Timing
+logger.time('operation');
+// ... some code ...
+logger.timeEnd('operation');
+
+// Grouping
+logger.group('Group Label');
+logger.log('Inside group');
+logger.groupEnd();
+
+logger.groupCollapsed('Collapsed Group');
+logger.log('Inside collapsed group');
+logger.groupEnd();
+
+// Clear console
+logger.clear();
+```
+
+### Styling
+
+The logger applies the following styles to prefixes:
+
+- **Text color**: Custom or predefined based on log level
+- **Background color**: Semi-transparent (0.2 opacity) matching the text color
+- **Border radius**: `4px`
+- **Padding**: `2px` vertical, `6px` horizontal
+- **Font weight**: Bold
+
+---
+
+## DOM Logger (`domLogger.ts`)
+
+A DOM-based logger that displays logs directly on the page without requiring browser dev tools. Perfect for debugging on mobile devices or when console access is limited.
+
+### Features
+
+- ✅ Displays logs directly on the page
+- ✅ Stacked vertically in top-left corner
+- ✅ Auto-removes after customizable duration (default: 5 seconds)
+- ✅ Smooth fade-in/fade-out animations
+- ✅ Color-coded by log type
+- ✅ Supports all log levels (log, info, warn, error, debug)
+- ✅ Scrollable for long messages
+- ✅ Auto-cleans up empty container
+
+### Installation
+
+```typescript
+import { domLog } from '#utils/log/domLogger.ts';
+```
+
+### Basic Usage
+
+```typescript
+// Basic log (displays for 5 seconds)
+domLog('Hello world');
+
+// Custom duration (10 seconds)
+domLog('This stays longer', { duration: 10000 });
+
+// Different log types
+domLog.info('Info message');
+domLog.warn('Warning message');
+domLog.error('Error message');
+domLog.debug('Debug message');
+```
+
+### API Reference
+
+#### `domLog(...args: unknown[]): void`
+
+#### `domLog(...args: unknown[], options?: DomLogOptions): void`
+
+Displays a log message on the page.
+
+**Parameters:**
+
+- `args`: Values to log (any type, will be formatted automatically)
+- `options`: Optional configuration object
+    - `duration`: Number of milliseconds before log disappears (default: `5000`)
+
+**Typed Methods:**
+
+- `domLog.info(...args, options?)` - Blue info log
+- `domLog.warn(...args, options?)` - Orange warning log
+- `domLog.error(...args, options?)` - Red error log
+- `domLog.debug(...args, options?)` - Gray debug log
+
+### Examples
+
+#### Basic Logging
+
+```typescript
+domLog('Simple message');
+domLog('Multiple', 'arguments', 123, { key: 'value' });
+```
+
+#### Custom Duration
+
+```typescript
+// Display for 10 seconds
+domLog('Long message', { duration: 10000 });
+
+// Display for 15 seconds
+domLog.error('Important error', { duration: 15000 });
+```
+
+#### Different Log Types
+
+```typescript
+domLog('Default log');
+domLog.info('Information');
+domLog.warn('Warning');
+domLog.error('Error occurred');
+domLog.debug('Debug info');
+```
+
+#### Complex Objects
+
+```typescript
+const data = { name: 'John', age: 30, nested: { value: 42 } };
+domLog('User data:', data);
+// Automatically formats objects as JSON
+```
+
+#### With Custom Duration
+
+```typescript
+domLog.info('Info that stays 10 seconds', { duration: 10000 });
+domLog.error('Critical error stays 20 seconds', { duration: 20000 });
+```
+
+### Styling
+
+Logs are displayed with:
+
+- **Position**: Fixed in top-left corner (`top: 20px`, `left: 20px`)
+- **Max width**: `400px`
+- **Stacking**: Vertical with `8px` gap
+- **Colors**:
+    - Log: White text on white background
+    - Info: Blue text (`#3399ff`) on blue background
+    - Warn: Orange text (`#ffaa00`) on orange background
+    - Error: Red text (`#ff3333`) on red background
+    - Debug: Gray text (`#999999`) on gray background
+- **Background opacity**: `0.2`
+- **Border**: `1px solid` matching text color
+- **Border radius**: `8px`
+- **Padding**: `12px` vertical, `16px` horizontal
+- **Animations**: Fade in/out with slide effect
+- **Max height**: `200px` with scroll for long content
+
+### Behavior
+
+- Logs automatically disappear after the specified duration
+- Container is automatically removed when empty
+- Logs stack vertically (newest at bottom)
+- Smooth animations on appear/disappear
+- Non-intrusive (pointer-events disabled except on log elements)
+
+---
+
+## Color Formats
+
+Both loggers support the following color formats:
+
+### Hex Colors
+
+```typescript
+'#312dfb'; // With hash
+'312dfb'; // Without hash (auto-added)
+```
+
+### RGB Colors
+
+```typescript
+'rgb(49, 45, 251)'; // Standard format
+'rgb(49 45 251)'; // Space-separated format
+```
+
+### RGBA Colors
+
+```typescript
+'rgba(49, 45, 251, 0.5)'; // With opacity
+```
+
+---
+
+## Use Cases
+
+### Console Logger
+
+- **Development debugging** - Easy identification of log sources
+- **Production logging** - Styled console output for monitoring
+- **Team collaboration** - Consistent logging format across team
+- **Component logging** - Different prefixes for different components
+
+### DOM Logger
+
+- **Mobile debugging** - View logs without dev tools
+- **Demo/presentation** - Show logs directly on screen
+- **User feedback** - Temporary notifications
+- **Remote debugging** - Logs visible without console access
+
+---
+
+## Tips
+
+1. **Console Logger**: Use descriptive IDs to identify log sources (e.g., component names, module names)
+2. **DOM Logger**: Use shorter durations for less important logs to avoid clutter
+3. **Color consistency**: Use the same color scheme across your application for better visual recognition
+4. **Performance**: Console logger creates prefixes/styles once, so it's efficient for frequent logging
+5. **DOM Logger cleanup**: The container automatically removes itself when empty, so no manual cleanup needed

--- a/src/scripts/utils/log/domLogger.ts
+++ b/src/scripts/utils/log/domLogger.ts
@@ -1,0 +1,213 @@
+interface DomLogOptions {
+    duration?: number; // Duration in milliseconds
+}
+
+type LogType = 'log' | 'info' | 'warn' | 'error' | 'debug';
+
+const DEFAULT_DURATION = 5000; // 5 seconds
+
+const LOG_COLORS = {
+    log: '#ffffff',
+    info: '#3399ff',
+    warn: '#ffaa00',
+    error: '#ff3333',
+    debug: '#999999'
+} as const;
+
+const LOG_BG_COLORS = {
+    log: 'rgba(0, 0, 0, 0.2)',
+    info: 'rgba(51, 153, 255, 0.2)',
+    warn: 'rgba(255, 170, 0, 0.2)',
+    error: 'rgba(255, 51, 51, 0.2)',
+    debug: 'rgba(153, 153, 153, 0.2)'
+} as const;
+
+const LOG_TYPE_ICONS = {
+    log: null,
+    info: '💡',
+    warn: '⚠️',
+    error: '🚨',
+    debug: '🐞'
+} as const;
+
+let container: HTMLDivElement | null = null;
+
+/**
+ * Creates or returns the DOM log container
+ */
+function getContainer(): HTMLDivElement {
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'dom-logger-container';
+        container.style.cssText = `
+            position: fixed;
+            top: 20px;
+            left: 20px;
+            z-index: 99999;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            max-width: 400px;
+            pointer-events: none;
+            user-select: none;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-size: 14px;
+        `;
+        document.body.appendChild(container);
+    }
+    return container;
+}
+
+/**
+ * Formats log arguments into a readable string
+ */
+function formatLogArgs(args: unknown[]): string {
+    return args
+        .map((arg) => {
+            if (arg === null) return 'null';
+            if (arg === undefined) return 'undefined';
+            if (typeof arg === 'object') {
+                try {
+                    return JSON.stringify(arg, null, 2);
+                } catch {
+                    return String(arg);
+                }
+            }
+            return String(arg);
+        })
+        .join(' ');
+}
+
+/**
+ * Creates a log element and adds it to the container
+ */
+function createLogElement(
+    message: string,
+    type: LogType = 'log',
+    duration: number = DEFAULT_DURATION
+): void {
+    const logContainer = getContainer();
+    const logElement = document.createElement('div');
+    const logTextElement = document.createElement('span');
+
+    const color = LOG_COLORS[type];
+    const bgColor = LOG_BG_COLORS[type];
+    const icon = LOG_TYPE_ICONS[type];
+
+    logElement.style.cssText = `
+        background: ${bgColor};
+        padding: 7px 14px;
+        border: 1px solid ${color};
+        border-radius: 6px;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+        opacity: 0;
+        transform: translateX(20px);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        pointer-events: auto;
+        overflow-y: clip auto;
+    `;
+
+    logTextElement.style.cssText = `
+        color: ${color};
+    `;
+
+    logTextElement.textContent = icon ? `${icon} • ${message}` : message;
+    logElement.appendChild(logTextElement);
+    logContainer.appendChild(logElement);
+
+    // Trigger animation
+    requestAnimationFrame(() => {
+        logElement.style.opacity = '1';
+        logElement.style.transform = 'translateX(0)';
+    });
+
+    // Remove after duration
+    setTimeout(() => {
+        logElement.style.opacity = '0';
+        logElement.style.transform = 'translateX(20px)';
+        setTimeout(() => {
+            if (logElement.parentNode) {
+                logElement.parentNode.removeChild(logElement);
+            }
+            // Remove container if empty
+            if (container && container.children.length === 0) {
+                container.remove();
+                container = null;
+            }
+        }, 300); // Wait for fade out animation
+    }, duration);
+}
+
+/**
+ * DOM logger function that displays logs directly on the page
+ * @param args - Values to log
+ * @param options - Optional configuration
+ * @param options.duration - Duration in milliseconds before log disappears (default: 5000)
+ *
+ * @example
+ * domLog('Hello world');
+ * domLog('Custom duration', { duration: 10000 });
+ * domLog.info('Info message');
+ * domLog.error('Error message');
+ */
+function domLog(...args: unknown[]): void;
+function domLog(args: unknown[], options?: DomLogOptions): void;
+function domLog(...argsOrOptions: unknown[]): void {
+    let logArgs: unknown[];
+    let options: DomLogOptions | undefined;
+
+    // Check if last arg is an options object
+    const lastArg = argsOrOptions[argsOrOptions.length - 1];
+    if (
+        lastArg &&
+        typeof lastArg === 'object' &&
+        !Array.isArray(lastArg) &&
+        'duration' in lastArg
+    ) {
+        options = lastArg as DomLogOptions;
+        logArgs = argsOrOptions.slice(0, -1);
+    } else {
+        logArgs = argsOrOptions;
+    }
+
+    const message = formatLogArgs(logArgs);
+    const duration = options?.duration ?? DEFAULT_DURATION;
+    createLogElement(message, 'log', duration);
+}
+
+/**
+ * Creates typed log methods (info, warn, error, debug)
+ */
+function createTypedLogMethod(type: LogType) {
+    return (...args: unknown[]): void => {
+        let logArgs: unknown[];
+        let options: DomLogOptions | undefined;
+
+        // Check if last arg is an options object
+        const lastArg = args[args.length - 1];
+        if (
+            lastArg &&
+            typeof lastArg === 'object' &&
+            !Array.isArray(lastArg) &&
+            'duration' in lastArg
+        ) {
+            options = lastArg as DomLogOptions;
+            logArgs = args.slice(0, -1);
+        } else {
+            logArgs = args;
+        }
+
+        const message = formatLogArgs(logArgs);
+        const duration = options?.duration ?? DEFAULT_DURATION;
+        createLogElement(message, type, duration);
+    };
+}
+
+// Attach typed methods
+domLog.info = createTypedLogMethod('info');
+domLog.warn = createTypedLogMethod('warn');
+domLog.error = createTypedLogMethod('error');
+domLog.debug = createTypedLogMethod('debug');
+
+export { domLog };

--- a/src/scripts/utils/log/index.ts
+++ b/src/scripts/utils/log/index.ts
@@ -1,0 +1,2 @@
+export * from './logger.ts';
+export * from './domLogger.ts';

--- a/src/scripts/utils/log/logger.ts
+++ b/src/scripts/utils/log/logger.ts
@@ -21,6 +21,8 @@ export interface Logger {
     clear: () => void;
 }
 
+const __DEBUG__ = import.meta.env.MODE === 'development';
+
 const PREDEFINED_COLORS_LIGHT = {
     error: '#ff3333',
     warn: '#ffaa00',

--- a/src/scripts/utils/log/logger.ts
+++ b/src/scripts/utils/log/logger.ts
@@ -1,0 +1,280 @@
+import { lighten, normalizeColor } from '@scripts/utils/colors';
+
+interface LoggerOptions {
+    id?: string;
+    color?: string;
+    backgroundColor?: string;
+}
+
+export interface Logger {
+    log: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+    debug: (...args: unknown[]) => void;
+    table: (tabularData: unknown) => void;
+    time: (label?: string) => void;
+    timeEnd: (label?: string) => void;
+    group: (...label: unknown[]) => void;
+    groupEnd: () => void;
+    groupCollapsed: (...label: unknown[]) => void;
+    clear: () => void;
+}
+
+const PREDEFINED_COLORS_LIGHT = {
+    error: '#ff3333',
+    warn: '#ffaa00',
+    info: '#3399ff',
+    debug: '#999999',
+    log: '#312dfb' // default, will be overridden by custom color
+} as const;
+
+const PREDEFINED_COLORS_DARK = {
+    error: lighten(PREDEFINED_COLORS_LIGHT.error, 0.5),
+    warn: lighten(PREDEFINED_COLORS_LIGHT.warn, 0.5),
+    info: lighten(PREDEFINED_COLORS_LIGHT.info, 0.5),
+    debug: lighten(PREDEFINED_COLORS_LIGHT.debug, 0.5),
+    log: lighten(PREDEFINED_COLORS_LIGHT.log, 0.5) // lighter version for dark mode
+} as const;
+
+/**
+ * Detects if the user's device is in dark mode
+ */
+function isDarkMode(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+/**
+ * Gets the appropriate color set based on dark mode
+ */
+function getColors() {
+    return isDarkMode() ? PREDEFINED_COLORS_DARK : PREDEFINED_COLORS_LIGHT;
+}
+
+/**
+ * Converts a color to a background color with opacity
+ */
+function colorToBgColor(color: string, opacity: number = 0.1): string {
+    // If it's already rgba, extract RGB values and update opacity
+    if (color.startsWith('rgba')) {
+        const match = color.match(/rgba?\(([^)]+)\)/);
+        if (match) {
+            const values = match[1].split(',').map((v) => v.trim());
+            return `rgba(${values[0]}, ${values[1]}, ${values[2]}, ${values[3] ?? opacity})`;
+        }
+    }
+
+    // If it's rgb, convert to rgba
+    if (color.startsWith('rgb')) {
+        const match = color.match(/rgb\(([^)]+)\)/);
+        if (match) {
+            return `rgba(${match[1]}, ${opacity})`;
+        }
+    }
+
+    // If it's hex, convert to rgba
+    if (color.startsWith('#')) {
+        const hex = color.slice(1);
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+    }
+
+    // Fallback: return as is
+    return color;
+}
+
+/**
+ * Creates a console method wrapper that preserves the original call site
+ * by using Function.prototype.bind to maintain the stack trace
+ *
+ * Using bind() ensures that browser devtools show the actual caller's file
+ * instead of this logger wrapper file
+ */
+function createConsoleMethod(
+    consoleMethod: typeof console.log,
+    prefix?: string,
+    style?: string
+): (...args: unknown[]) => void {
+    if (prefix && style) {
+        // Use bind to prepend prefix and style while preserving call site
+        // This creates a bound function that behaves as if console.log was called directly
+        return Function.prototype.bind.call(consoleMethod, console, prefix, style);
+    } else {
+        // For methods without prefix/style, bind directly to preserve call site
+        return Function.prototype.bind.call(consoleMethod, console);
+    }
+}
+
+/**
+ * Creates a stylized logger with predefined colors and custom log color
+ * @param options - Logger configuration
+ * @param options.id - Optional prefix identifier (e.g., 'LOCO'). If not provided, no prefix is added.
+ * @param options.color - Custom color for log method (hex or rgb)
+ * @returns Logger object with all console methods
+ *
+ * @example
+ * const logger = createLogger({ id: 'LOCO', color: '#312dfb' });
+ * logger.log('Hello'); // Outputs: LOCO Hello (in #312dfb)
+ * logger.error('Error!'); // Outputs: LOCO • error Error! (in red)
+ *
+ * @example
+ * const logger = createLogger({ color: '#312dfb' });
+ * logger.log('Hello'); // Outputs: Hello (no prefix, but with color if supported)
+ */
+export function createLogger(options: LoggerOptions = {}): Logger {
+    /* Disable custom Logger in production */
+    if (!__DEBUG__) {
+        return {
+            log: () => {},
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+            debug: () => {},
+            table: () => {},
+            time: () => {},
+            timeEnd: () => {},
+            group: () => {},
+            groupEnd: () => {},
+            groupCollapsed: () => {},
+            clear: () => {}
+        };
+    }
+
+    const { id, color, backgroundColor } = options;
+    const colors = getColors();
+    // const bgColors = getBgColors();
+    const normalizedColor = color ? normalizeColor(color) : null;
+    const logColor = normalizedColor
+        ? lighten(normalizedColor, isDarkMode() ? 0.4 : 0)
+        : colors.log;
+
+    // const logBgColor = color
+    //     ? colorToBgColor(logColor)
+    //     : colorToBgColor(backgroundColor ?? bgColors.log);
+    const logBgColor = backgroundColor
+        ? colorToBgColor(backgroundColor, 1)
+        : lighten(colorToBgColor(logColor, 0.2), isDarkMode() ? 0.4 : 0);
+    const hasPrefix = Boolean(id);
+
+    /**
+     * Creates CSS style string for the prefix
+     */
+    function createStyle(color: string, bgColor?: string, borderColor?: string): string {
+        const bgStyle = bgColor
+            ? `background: ${bgColor}; border-radius: 4px; padding: 1px 6px;`
+            : '';
+        const borderStyle = borderColor ? `border-left: 2px solid ${borderColor};` : '';
+        return `color: ${color}; font-weight: bold; text-box: trim-both cap alphabetic; ${bgStyle} ${borderStyle} padding: 4px 5px;`;
+    }
+
+    // Create all prefixes and styles once (only if id is provided)
+    const prefixes = hasPrefix
+        ? {
+              log: `%c${id}`,
+              info: `%c${id}`,
+              warn: `%c${id}`,
+              error: `%c${id}`,
+              debug: `%c${id}`,
+              table: `%c${id}`,
+              time: `%c${id} • time`,
+              timeEnd: `%c${id} • timeEnd`,
+              group: `%c${id}`,
+              groupCollapsed: `%c${id}`
+          }
+        : null;
+
+    const styles = hasPrefix
+        ? {
+              log: createStyle(logColor, logBgColor),
+              info: createStyle(logColor, logBgColor, colors.info),
+              warn: createStyle(logColor, logBgColor, colors.warn),
+              error: createStyle(logColor, logBgColor, colors.error),
+              debug: createStyle(logColor, logBgColor, colors.debug),
+              table: createStyle(logColor, logBgColor),
+              time: createStyle(logColor, logBgColor),
+              timeEnd: createStyle(logColor, logBgColor),
+              group: createStyle(logColor, logBgColor),
+              groupCollapsed: createStyle(logColor, logBgColor)
+          }
+        : null;
+
+    return {
+        log: createConsoleMethod(
+            console.log,
+            hasPrefix && prefixes ? prefixes.log : undefined,
+            hasPrefix && styles ? styles.log : undefined
+        ),
+
+        info: createConsoleMethod(
+            console.info,
+            hasPrefix && prefixes ? prefixes.info : undefined,
+            hasPrefix && styles ? styles.info : undefined
+        ),
+
+        warn: createConsoleMethod(
+            console.warn,
+            hasPrefix && prefixes ? prefixes.warn : undefined,
+            hasPrefix && styles ? styles.warn : undefined
+        ),
+
+        error: createConsoleMethod(
+            console.error,
+            hasPrefix && prefixes ? prefixes.error : undefined,
+            hasPrefix && styles ? styles.error : undefined
+        ),
+
+        debug: createConsoleMethod(
+            console.debug,
+            hasPrefix && prefixes ? prefixes.debug : undefined,
+            hasPrefix && styles ? styles.debug : undefined
+        ),
+
+        table: (tabularData: unknown) => {
+            if (hasPrefix && prefixes && styles) {
+                // Prefix log will show logger.ts, but table call will show correct call site
+                console.log(prefixes.table, styles.table);
+            }
+            // Use bind to preserve call site for the actual table call
+            Function.prototype.bind.call(console.table, console)(tabularData);
+        },
+
+        time: (label?: string) => {
+            if (hasPrefix && prefixes && styles) {
+                // Prefix log will show logger.ts, but time call will show correct call site
+                console.log(prefixes.time, styles.time);
+            }
+            // Use bind to preserve call site
+            Function.prototype.bind.call(console.time, console)(label);
+        },
+
+        timeEnd: (label?: string) => {
+            if (hasPrefix && prefixes && styles) {
+                // Prefix log will show logger.ts, but timeEnd call will show correct call site
+                console.log(prefixes.timeEnd, styles.timeEnd);
+            }
+            // Use bind to preserve call site
+            Function.prototype.bind.call(console.timeEnd, console)(label);
+        },
+
+        group: createConsoleMethod(
+            console.group,
+            hasPrefix && prefixes ? prefixes.group : undefined,
+            hasPrefix && styles ? styles.group : undefined
+        ),
+
+        groupEnd: Function.prototype.bind.call(console.groupEnd, console),
+
+        groupCollapsed: createConsoleMethod(
+            console.groupCollapsed,
+            hasPrefix && prefixes ? prefixes.groupCollapsed : undefined,
+            hasPrefix && styles ? styles.groupCollapsed : undefined
+        ),
+
+        clear: () => {
+            console.clear();
+        }
+    };
+}

--- a/src/scripts/utils/maths.ts
+++ b/src/scripts/utils/maths.ts
@@ -2,7 +2,7 @@ const mapRange = (min: number, max: number, nmin: number, nmax: number, value: n
     return ((value - min) / (max - min)) * (nmax - nmin) + nmin;
 };
 
-const clamp = (min: number, max: number, value: number) => {
+const clamp = (value: number, min: number = 0, max: number = 1) => {
     return Math.max(min, Math.min(value, max));
 };
 


### PR DESCRIPTION
## Summary

**`utils/colors/lighten(color, amount)`**
- Lightens hex or rgb(a) strings toward white by a 0–1 factor
- Used internally by `createLogger` for dark-mode color adaptation

**`utils/colors/normalizeColor(color)`**
- Normalizes `0x...`, bare hex, and `rgb(...)` to a canonical CSS string

**`utils/log/createLogger({ id, color, backgroundColor })`**
- Styled `console` wrapper with color-coded log levels (log/info/warn/error/debug)
- Reads `prefers-color-scheme` and auto-lightens colors in dark mode
- Preserves devtools call-site by binding via `Function.prototype.bind` (no misleading stack frames)
- Returns no-op stubs in production (`__DEBUG__` guard) — zero cost at runtime

**`utils/log/domLog(...args)`**
- Renders log entries as animated fixed-position DOM overlays
- Auto-dismisses after a configurable duration (default 5 s)
- Supports `log`, `info`, `warn`, `error`, `debug` variants
- Intended for on-device debugging where browser DevTools are unavailable

## Why

`createLogger` replaces ad-hoc `console.log` calls scattered across stores and components. `domLog` fills the gap when DevTools are inaccessible (remote devices, iframe contexts).

## Dependencies

- `utils/maths` — `lighten` uses `clamp`