### PR TITLE
feat(utils): add DOM utilities

### DIFF
--- a/src/scripts/utils/dom/dom.ts
+++ b/src/scripts/utils/dom/dom.ts
@@ -1,0 +1,16 @@
+const $html = document.documentElement;
+const $body = document.body;
+
+export { $html, $body };
+
+export function forceReflow(node: HTMLElement = $body): void {
+    void node.offsetHeight;
+}
+
+export const onDOMReady = (callback: () => void): void => {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    } else {
+        callback();
+    }
+};

--- a/src/scripts/utils/dom/index.ts
+++ b/src/scripts/utils/dom/index.ts
@@ -1,0 +1,2 @@
+export * from './dom.ts';
+export * from './useBounding.ts';

--- a/src/scripts/utils/dom/useBounding.ts
+++ b/src/scripts/utils/dom/useBounding.ts
@@ -1,0 +1,61 @@
+import { $scroll } from '@scripts/stores/scroll.ts';
+import { map, type WritableAtom } from 'nanostores';
+
+export interface DynamicBoundingRect {
+    node: HTMLElement;
+    data: WritableAtom<DOMRectReadOnly>;
+    update: () => void;
+    dispose: () => void;
+}
+
+export function useBoundingRect(
+    node: HTMLElement,
+    options: {
+        callback: (rect: DOMRectReadOnly) => void;
+        updateOnResize: boolean;
+        updateOnScroll: boolean;
+    } = {
+        callback: () => {},
+        updateOnResize: true,
+        updateOnScroll: false
+    }
+): DynamicBoundingRect {
+    if (!(node instanceof HTMLElement)) {
+        throw new TypeError('Expected an HTMLElement');
+    }
+
+    let _unlistenResize: () => void = () => {};
+    let _unlistenScroll: () => void = () => {};
+
+    const data = map(node.getBoundingClientRect());
+    const update = () => {
+        data.set(node.getBoundingClientRect());
+        options.callback(data.get());
+    };
+
+    if (options.updateOnResize) {
+        const RO = new ResizeObserver(update);
+        RO.observe(node);
+        _unlistenResize = () => {
+            RO.unobserve(node);
+            RO.disconnect();
+        };
+    }
+
+    if (options.updateOnScroll) {
+        _unlistenScroll = $scroll.listen(update);
+    }
+
+    update();
+
+    return {
+        node,
+        update,
+        data,
+        dispose: () => {
+            _unlistenResize?.();
+            _unlistenScroll?.();
+            data.off();
+        }
+    };
+}


### PR DESCRIPTION
## Summary

**`utils/dom/dom.ts`**
- `$html` / `$body` — cached `document.documentElement` / `document.body` refs
- `forceReflow(node?)` — reads `offsetHeight` to force a synchronous layout recalculation
- `onDOMReady(cb)` — calls `cb` immediately if the DOM is already loaded, otherwise waits for `DOMContentLoaded`

**`utils/dom/useBounding.ts`**
- `useBoundingRect(el, options)` — reactive `DOMRectReadOnly` backed by a nanostores `map` atom
- `updateOnResize` — uses `ResizeObserver` to refresh on element size changes
- `updateOnScroll` — subscribes to `$scroll` to refresh on scroll position changes
- Returns `{ data, update, dispose }` — manually refresh or clean up listeners

## Why

`$html` and `$body` are referenced in multiple stores and components. Centralizing them avoids repeated `document.documentElement` calls and makes tree-shaking easier. `useBoundingRect` replaces ad-hoc `getBoundingClientRect` patterns with a reactive atom that keeps itself in sync.

## Dependencies

- `stores/scroll` — `useBoundingRect` optionally subscribes to `$scroll` for scroll-aware rect updates

> **Note:** `stores/scroll`, `stores/deviceInfos` import from `@scripts/utils/dom/dom.ts` and must be merged after this PR.