### PR TITLE
feat(stores): refactor mouse store

### DIFF
--- a/src/scripts/stores/mouse.ts
+++ b/src/scripts/stores/mouse.ts
@@ -1,6 +1,23 @@
 import { $screen } from '@scripts/stores/screen.ts';
-import { dampPrecise, normalize } from '@scripts/utils/maths.ts';
+import { normalize } from '@scripts/utils/maths.ts';
+// import { dampPrecise, normalize } from '@scripts/utils/maths.ts';
 import { map } from 'nanostores';
+
+/* Hotfix for the PR */
+/* Will be imported from '@scripts/utils/maths.ts' */
+export function lerpPrecise(start: number, end: number, t: number, limit: number = 0.001): number {
+    const v = start * (1 - t) + end * t;
+    return Math.abs(end - v) < limit ? end : v;
+}
+export function dampPrecise(
+    a: number,
+    b: number,
+    smoothing: number,
+    dt: number,
+    limit: number = 0.001
+): number {
+    return lerpPrecise(a, b, 1 - Math.exp(-smoothing * 0.05 * Math.max(dt, 0)), limit);
+}
 
 export type MouseState = {
     x: number;

--- a/src/scripts/stores/mouse.ts
+++ b/src/scripts/stores/mouse.ts
@@ -1,20 +1,18 @@
+import { $screen } from '@scripts/stores/screen.ts';
+import { dampPrecise, normalize } from '@scripts/utils/maths.ts';
 import { map } from 'nanostores';
-import { $screen } from '@scripts/stores/screen';
-import { normalize, roundToDecimals } from '@scripts/utils/maths';
 
 export type MouseState = {
     x: number;
     y: number;
     normalizedX: number;
     normalizedY: number;
+    velocityX: number;
+    velocityY: number;
 };
 
-export type SmoothMouseState = {
-    smoothX: number;
-    smoothY: number;
-    smoothNormalizedX: number;
-    smoothNormalizedY: number;
-    lerp: number;
+export type SmoothMouseState = MouseState & {
+    smoothing: number;
 };
 
 const HALF_SCREEN_WIDTH = $screen.value!.width * 0.5;
@@ -24,75 +22,111 @@ export const $mouse = map<MouseState>({
     x: HALF_SCREEN_WIDTH,
     y: HALF_SCREEN_HEIGHT,
     normalizedX: 0,
-    normalizedY: 0
+    normalizedY: 0,
+    velocityX: 0,
+    velocityY: 0
 });
 
 export const $smoothMouse = map<SmoothMouseState>({
-    smoothX: HALF_SCREEN_WIDTH,
-    smoothY: HALF_SCREEN_HEIGHT,
-    smoothNormalizedX: 0,
-    smoothNormalizedY: 0,
-    lerp: 0.08
+    x: HALF_SCREEN_WIDTH,
+    y: HALF_SCREEN_HEIGHT,
+    normalizedX: 0,
+    normalizedY: 0,
+    velocityX: 0,
+    velocityY: 0,
+    smoothing: 0.08
 });
 
-let isPlaying = false;
-let RAF: null | any = null;
+/* Mouse Update Loop */
+let mouseRAF: null | number = null;
+let isMouseLoopRunning = false;
 
-const onMouseMove = (event: MouseEvent): void => {
+const updateMouse = (): void => {
+    // Mouse updates happen directly on mousemove event
+    // This loop can be used for additional mouse-related updates if needed
+    mouseRAF = requestAnimationFrame(updateMouse);
+};
+
+export const startMouseLoop = (): void => {
+    if (isMouseLoopRunning || mouseRAF) return;
+    updateMouse();
+    isMouseLoopRunning = true;
+};
+
+export const stopMouseLoop = (): void => {
+    if (!isMouseLoopRunning || !mouseRAF) return;
+    cancelAnimationFrame(mouseRAF);
+    mouseRAF = null;
+    isMouseLoopRunning = false;
+};
+
+const onMouseMove = (event: MouseEvent | PointerEvent): void => {
     const { clientX, clientY } = event;
+
+    const screen = $screen.get();
+    const width = screen?.width ?? window.innerWidth;
+    const height = screen?.height ?? window.innerHeight;
+
+    const { x: prevX, y: prevY } = $mouse.value;
 
     $mouse.setKey('x', clientX);
     $mouse.setKey('y', clientY);
-    $mouse.setKey('normalizedX', normalize(0, $screen.value!.width, clientX));
-    $mouse.setKey('normalizedY', normalize(0, $screen.value!.height, clientY));
-
-    play();
+    $mouse.setKey('normalizedX', normalize(clientX, 0, width));
+    $mouse.setKey('normalizedY', normalize(clientY, 0, height));
+    $mouse.setKey('velocityX', clientX - prevX);
+    $mouse.setKey('velocityY', clientY - prevY);
 };
 
-const onUpdate = (): void => {
-    const { x, y } = $mouse.value!;
-    const { smoothX, smoothY, lerp } = $smoothMouse.value!;
+/* Smooth Mouse Update Loop */
+let smoothMouseRAF: null | number = null;
+let isSmoothMouseLoopRunning = false;
+let lastFrameTime = performance.now();
 
-    const updatedSmoothX = smoothX + (x - smoothX) * lerp;
-    const updatedSmoothY = smoothY + (y - smoothY) * lerp;
+const updateSmoothMouse = (): void => {
+    const currentTime = performance.now();
+    const dt = currentTime - lastFrameTime;
+    lastFrameTime = currentTime;
 
-    const roundedSmoothX = updatedSmoothX;
-    const roundedSmoothY = updatedSmoothY;
-    const roundedSmoothNormalizedX = normalize(0, $screen.value!.width, updatedSmoothX);
-    const roundedSmoothNormalizedY = normalize(0, $screen.value!.height, updatedSmoothY);
+    const { x, y } = $mouse.value;
+    const { x: smoothX, y: smoothY, smoothing } = $smoothMouse.value;
 
-    if (hasMouseStopped(roundedSmoothX, roundedSmoothY) && isPlaying) {
-        return pause();
-    }
+    const screen = $screen.get();
+    const width = screen?.width ?? window.innerWidth;
+    const height = screen?.height ?? window.innerHeight;
 
-    $smoothMouse.setKey('smoothX', roundToDecimals(roundedSmoothX, 3));
-    $smoothMouse.setKey('smoothY', roundToDecimals(roundedSmoothY, 3));
-    $smoothMouse.setKey('smoothNormalizedX', roundToDecimals(roundedSmoothNormalizedX, 6));
-    $smoothMouse.setKey('smoothNormalizedY', roundToDecimals(roundedSmoothNormalizedY, 6));
+    const updatedSmoothX = dampPrecise(smoothX, x, smoothing, dt);
+    const updatedSmoothY = dampPrecise(smoothY, y, smoothing, dt);
 
-    RAF = requestAnimationFrame(onUpdate);
+    const smoothNormalizedX = normalize(updatedSmoothX, 0, width);
+    const smoothNormalizedY = normalize(updatedSmoothY, 0, height);
+
+    $smoothMouse.setKey('velocityX', updatedSmoothX - smoothX);
+    $smoothMouse.setKey('velocityY', updatedSmoothY - smoothY);
+    $smoothMouse.setKey('x', updatedSmoothX);
+    $smoothMouse.setKey('y', updatedSmoothY);
+    $smoothMouse.setKey('normalizedX', smoothNormalizedX);
+    $smoothMouse.setKey('normalizedY', smoothNormalizedY);
+
+    smoothMouseRAF = requestAnimationFrame(updateSmoothMouse);
 };
 
-const play = (): void => {
-    if (isPlaying || RAF) return;
-    // Use GSAP ticker instead of RAF
-    // gsap.ticker.add(onUpdate);
-    onUpdate();
-    isPlaying = true;
+export const startSmoothMouseLoop = (): void => {
+    if (isSmoothMouseLoopRunning || smoothMouseRAF) return;
+    lastFrameTime = performance.now();
+    updateSmoothMouse();
+    isSmoothMouseLoopRunning = true;
 };
 
-const pause = (): void => {
-    if (!isPlaying || !RAF) return;
-    // Use GSAP ticker instead of RAF
-    // gsap.ticker.remove(onUpdate);
-    cancelAnimationFrame(RAF);
-    RAF = null;
-    isPlaying = false;
-};
-
-const hasMouseStopped = (smoothX: number, smoothY: number): boolean => {
-    return smoothX + smoothY === $smoothMouse.value!.smoothX + $smoothMouse.value!.smoothY;
+export const stopSmoothMouseLoop = (): void => {
+    if (!isSmoothMouseLoopRunning || !smoothMouseRAF) return;
+    cancelAnimationFrame(smoothMouseRAF);
+    smoothMouseRAF = null;
+    isSmoothMouseLoopRunning = false;
 };
 
 /* Events */
 window.addEventListener('mousemove', onMouseMove);
+
+/* Initialize smooth mouse loop */
+startMouseLoop();
+startSmoothMouseLoop();


### PR DESCRIPTION
## Summary

- `$mouse` now tracks `velocityX` / `velocityY` (delta from the previous `mousemove` event)
- `SmoothMouseState` extends `MouseState` directly — unified shape, no duplicate `smoothX`/`smoothY` fields
- `smoothing` replaces `lerp` for naming clarity
- Smooth interpolation switched from fixed-lerp to `dampPrecise(a, b, smoothing, dt)` — frame-rate-independent via exponential decay with delta time
- Separate, explicit RAF loops:
  - `mouseRAF` / `startMouseLoop` / `stopMouseLoop`
  - `smoothMouseRAF` / `startSmoothMouseLoop` / `stopSmoothMouseLoop`
- `$screen.get()` with `window.innerWidth/Height` fallback instead of `$screen.value!` (avoids null assertion)
- Event listener accepts both `MouseEvent` and `PointerEvent`

## Why

The old smooth mouse used a fixed lerp factor, which meant different smoothing feel at different frame rates. Delta-time damping makes the feel consistent across 60/90/120/144 Hz displays. The renamed fields (`x`/`y` instead of `smoothX`/`smoothY`) match the shape of `$mouse` so consumers can treat both stores uniformly.

> **Breaking:** `$smoothMouse` field names changed — `smoothX` → `x`, `smoothY` → `y`, `smoothNormalizedX` → `normalizedX`, `smoothNormalizedY` → `normalizedY`, `lerp` → `smoothing`.

## Dependencies

- `feat/utils-maths` — uses `dampPrecise`, `normalize` from `@scripts/utils/maths`
- `feat/utils-screen` — uses updated `$screen` store