### PR TITLE
feat(stores): expand scroll store with computed atoms and CSS class sync

### DIFF
--- a/src/scripts/stores/scroll.ts
+++ b/src/scripts/stores/scroll.ts
@@ -1,4 +1,6 @@
-import { map } from 'nanostores';
+import { $screen } from '@scripts/stores/screen.ts';
+import { $html } from '@scripts/utils/dom/dom.ts';
+import { atom, computed, map, subscribeKeys } from 'nanostores';
 
 export type ScrollValues = {
     scroll: number;
@@ -15,3 +17,31 @@ export const $scroll = map<ScrollValues>({
     direction: 0,
     progress: 0
 });
+
+export const $hasScrolled = computed($scroll, (store) => {
+    return store.scroll > 40;
+});
+
+export const $hasPassedFold = computed($scroll, (store) => {
+    return store.scroll > $screen.get().height;
+});
+
+$hasScrolled.subscribe((hasScrolled) => {
+    $html.classList.toggle('has-scrolled', hasScrolled);
+});
+
+$hasPassedFold.subscribe((hasPassedFold) => {
+    $html.classList.toggle('has-passed-fold', hasPassedFold);
+});
+
+subscribeKeys($scroll, ['direction'], (store) => {
+    $html.classList.toggle('is-scrolling-up', store.direction === -1);
+    $html.classList.toggle('is-scrolling-down', store.direction === 1);
+});
+
+export const $hasScrolledBeyond = (value: number) => {
+    return computed($scroll, (store) => store.scroll > value);
+};
+
+export const $hasScrolledPastHeader = atom(false);
+export const $hasReachedFooter = atom(false);

--- a/src/scripts/stores/scroll.ts
+++ b/src/scripts/stores/scroll.ts
@@ -1,5 +1,6 @@
 import { $screen } from '@scripts/stores/screen.ts';
-import { $html } from '@scripts/utils/dom/dom.ts';
+// import { $html } from '@scripts/utils/dom/dom.ts';
+const $html = document.documentElement;
 import { atom, computed, map, subscribeKeys } from 'nanostores';
 
 export type ScrollValues = {


### PR DESCRIPTION
## Summary

- `$hasScrolled` — `computed($scroll)`, `true` when `scroll > 40`
- `$hasPassedFold` — `computed($scroll)`, `true` when `scroll > $screen.height`
- `$hasScrolledBeyond(value)` — factory: returns a computed atom for any arbitrary scroll threshold
- `$hasScrolledPastHeader` / `$hasReachedFooter` — plain `atom(false)`, set manually by layout components
- CSS class auto-sync on `<html>`:
  - `has-scrolled` / `has-passed-fold` — toggled by the computed atoms above
  - `is-scrolling-up` / `is-scrolling-down` — toggled via `subscribeKeys($scroll, ['direction'])`

## Why

Scroll-triggered layout states (`has-scrolled`, `is-scrolling-up`, etc.) were previously handled ad-hoc in multiple components. Centralizing them in the store means a single subscription drives all CSS class changes, and any component can subscribe to the reactive atoms without duplicating threshold logic.

## Dependencies

- `feat/utils-dom` — imports `$html` from `@scripts/utils/dom/dom`
- `feat/utils-screen` — `$hasPassedFold` reads `$screen.get().height`